### PR TITLE
DM-22130: Deploy SAL 4/SalObj 5 in Tucson Test Stand

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,8 +12,8 @@ pipeline {
                     sh """
                     docker network create \${network_name}
                     chmod -R a+rw \${WORKSPACE}
-                    container=\$(docker run -v \${WORKSPACE}:/home/saluser/repo/ -td --rm --net \${network_name} --name \${container_name} lsstts/develop-env:salobj4_b64)
-                    docker exec -u saluser \${container} sh -c \"source ~/.setup.sh && make_idl_files.py ATMCS ATPtg ATAOS ATPneumatics ATHexapod ATDome ATDomeTrajectory && cd repo && eups declare -r . -t saluser && setup ts_standardscripts -t saluser && py.test --junitxml=tests/.tests/junit.xml\"
+                    container=\$(docker run -v \${WORKSPACE}:/home/saluser/repo/ -td --rm --net \${network_name} --name \${container_name} lsstts/develop-env:salobj4_develop)
+                    docker exec -u saluser \${container} sh -c \"source ~/.setup.sh && cd /home/saluser/repo/ && eups declare -r . -t saluser && setup ts_standardscripts -t saluser && py.test --junitxml=tests/.tests/junit.xml\"
                     """
                 }
             }
@@ -37,11 +37,9 @@ pipeline {
         }
         cleanup {
             sh """
+                docker exec -u root --privileged \${container_name} sh -c \"chmod -R a+rw /home/saluser/repo/ \"
                 docker stop \${container_name} || echo Could not stop container
                 docker network rm \${network_name} || echo Could not remove network
-                container=\$(docker run -v \${WORKSPACE}:/home/saluser/repo/ -td --rm lsstts/salobj:master)
-                docker exec -u root --privileged \${container} sh -c \"chmod -R a+rw /home/saluser/repo/ \"
-                docker stop \${container}
             """
             deleteDir()
         }

--- a/python/lsst/ts/standardscripts/auxtel/atcam_take_image.py
+++ b/python/lsst/ts/standardscripts/auxtel/atcam_take_image.py
@@ -45,11 +45,8 @@ class ATCamTakeImage(salobj.BaseScript):
     """
     def __init__(self, index):
         super().__init__(index=index, descr="Test ATCamTakeImage")
-        self.atcam = salobj.Remote(domain=self.domain, name="ATCamera")
-        self.atspec = salobj.Remote(domain=self.domain, name="ATSpectrograph")
 
-        self.latiss = LATISS(atcam=self.atcam,
-                             atspec=self.atspec)
+        self.latiss = LATISS(self.domain)
         self.cmd_timeout = 60.  # command timeout (sec)
         # large because of an issue with one of the components
 

--- a/python/lsst/ts/standardscripts/auxtel/detector_characterization/get_std_flat_dataset.py
+++ b/python/lsst/ts/standardscripts/auxtel/detector_characterization/get_std_flat_dataset.py
@@ -60,12 +60,8 @@ class ATGetStdFlatDataset(salobj.BaseScript):
 
         super().__init__(index=index,
                          descr="Take Flat field sensor characterization data.")
-        self.atcam = salobj.Remote(domain=self.domain, name="ATCamera",
-                                   include=["takeImages", "endReadout"])
-        self.atspec = salobj.Remote(domain=self.domain, name="ATSpectrograph",
-                                    include=["changeFilter", "changeDisperser", "moveLinearStage"])
 
-        self.latiss = LATISS(atcam=self.atcam, atspec=self.atspec)
+        self.latiss = LATISS(self.domain)
 
         self.read_out_time = self.latiss.read_out_time
         self.cmd_timeout = 30.

--- a/python/lsst/ts/standardscripts/auxtel/latiss.py
+++ b/python/lsst/ts/standardscripts/auxtel/latiss.py
@@ -26,11 +26,10 @@ from lsst.ts import salobj
 
 
 class LATISS:
-    """LSST Auxiliary Telescope Image and Slit less Spectrograph.
+    """LSST Auxiliary Telescope Image and Slit less Spectrograph (LATISS).
 
-    Implement high level functionality for LATISS, a high level instrument
-    which is the combination of ATCamera, ATSpectrograph, ATHeaderService and
-    ATArchiver CSCs.
+    LATISS encapsulates core functionality from the following CSCs ATCamera,
+    ATSpectrograph, ATHeaderService and ATArchiver CSCs.
 
     Parameters
     ----------
@@ -309,5 +308,4 @@ class LATISS:
         return self
 
     async def __aexit__(self, *args):
-
         await self.close()

--- a/python/lsst/ts/standardscripts/auxtel/latiss.py
+++ b/python/lsst/ts/standardscripts/auxtel/latiss.py
@@ -22,33 +22,62 @@ __all__ = ['LATISS']
 
 import asyncio
 
+from lsst.ts import salobj
+
 
 class LATISS:
     """LSST Auxiliary Telescope Image and Slit less Spectrograph.
 
     Implement high level functionality for LATISS, a high level instrument
-    which is the combination of ATCamera and ATSpectrograph CSCs.
+    which is the combination of ATCamera, ATSpectrograph, ATHeaderService and
+    ATArchiver CSCs.
 
     Parameters
     ----------
-    atcam : `lsst.ts.salobj.Remote`
-        Remote for the ATCamera.
-    atspec : `lsst.ts.salobj.Remote`
-        Remote for the ATSpectrograph.
+    domain : `lsst.ts.salobj.Domain`
+        Domain for remotes. If `None` create a domain.
     """
 
-    def __init__(self, atcam, atspec):
+    def __init__(self, domain=None):
 
-        self.atcam = atcam
-        self.atspec = atspec
+        self._components = ["ATCamera", "ATSpectrograph", "ATHeaderService", "ATArchiver"]
+
+        self.components = [comp.lower() for comp in self._components]
+
+        self._remotes = {}
+
+        self.domain = domain if domain is not None else salobj.Domain()
+
+        for i in range(len(self._components)):
+            self._remotes[self.components[i]] = salobj.Remote(self.domain,
+                                                              self._components[i])
+
+        self.start_task = asyncio.gather(*[self._remotes[r].start_task for r in self._remotes])
 
         self.read_out_time = 2.  # readout time (sec)
         self.shutter_time = 1  # time to open or close shutter (sec)
 
-        self.cmd_timeout = 30.
-        self.end_readout_timeout = 60.
+        self.fast_timeout = 5.
+        self.long_timeout = 30.
+        self.long_long_timeout = 120.
 
         self.cmd_lock = asyncio.Lock()
+
+    @property
+    def atcamera(self):
+        return self._remotes["atcamera"]
+
+    @property
+    def atspectrograph(self):
+        return self._remotes["atspectrograph"]
+
+    @property
+    def atheaderservice(self):
+        return self._remotes["atheaderservice"]
+
+    @property
+    def atarchiver(self):
+        return self._remotes["atarchiver"]
 
     async def take_bias(self, nbias, checkpoint=None):
         """Take a series of bias images.
@@ -208,20 +237,20 @@ class LATISS:
             # FIXME: Current version of ATCamera software is not set up to take
             # images with numImages > 1, so this is fixed at 1 for now and we
             # loop through any set of images we want to take. (2019/03/11)
-            self.atcam.cmd_takeImages.set(numImages=1,
-                                          expTime=float(exp_time),
-                                          shutter=bool(shutter),
-                                          imageType=str(image_type),
-                                          groupId=str(group_id),
-                                          science=bool(science),
-                                          guide=bool(guide),
-                                          wfs=bool(wfs)
-                                          )
+            self.atcamera.cmd_takeImages.set(numImages=1,
+                                             expTime=float(exp_time),
+                                             shutter=bool(shutter),
+                                             imageType=str(image_type),
+                                             groupId=str(group_id),
+                                             science=bool(science),
+                                             guide=bool(guide),
+                                             wfs=bool(wfs)
+                                             )
 
-            timeout = self.read_out_time + self.cmd_timeout + self.end_readout_timeout
-            self.atcam.evt_endReadout.flush()
-            await self.atcam.cmd_takeImages.start(timeout=timeout+exp_time)
-            return await self.atcam.evt_endReadout.next(flush=False, timeout=timeout)
+            timeout = self.read_out_time + self.long_timeout + self.long_long_timeout
+            self.atcamera.evt_endReadout.flush()
+            await self.atcamera.cmd_takeImages.start(timeout=timeout + exp_time)
+            return await self.atcamera.evt_endReadout.next(flush=False, timeout=timeout)
 
     async def setup_atspec(self, filter=None, grating=None,
                            linear_stage=None):
@@ -241,32 +270,44 @@ class LATISS:
         setup_coroutines = []
         if filter is not None:
             if isinstance(filter, int):
-                self.atspec.cmd_changeFilter.set(filter=filter,
-                                                 name='')
+                self.atspectrograph.cmd_changeFilter.set(filter=filter,
+                                                         name='')
             elif type(filter) == str:
-                self.atspec.cmd_changeFilter.set(filter=0,
-                                                 name=filter)
+                self.atspectrograph.cmd_changeFilter.set(filter=0,
+                                                         name=filter)
             else:
                 raise RuntimeError(f"Filter must be a string or an int, got "
                                    f"{type(filter)}:{filter}")
-            setup_coroutines.append(self.atspec.cmd_changeFilter.start(timeout=self.cmd_timeout))
+            setup_coroutines.append(self.atspectrograph.cmd_changeFilter.start(timeout=self.long_timeout))
 
         if grating is not None:
             if isinstance(grating, int):
-                self.atspec.cmd_changeDisperser.set(disperser=grating,
-                                                    name='')
+                self.atspectrograph.cmd_changeDisperser.set(disperser=grating,
+                                                            name='')
             elif type(grating) == str:
-                self.atspec.cmd_changeDisperser.set(disperser=0,
-                                                    name=grating)
+                self.atspectrograph.cmd_changeDisperser.set(disperser=0,
+                                                            name=grating)
             else:
                 raise RuntimeError(f"Grating must be a string or an int, got "
                                    f"{type(grating)}:{grating}")
-            setup_coroutines.append(self.atspec.cmd_changeDisperser.start(timeout=self.cmd_timeout))
+            setup_coroutines.append(self.atspectrograph.cmd_changeDisperser.start(timeout=self.long_timeout))
 
         if linear_stage is not None:
-            self.atspec.cmd_moveLinearStage.set(distanceFromHome=float(linear_stage))
-            setup_coroutines.append(self.atspec.cmd_moveLinearStage.start(timeout=self.cmd_timeout))
+            self.atspectrograph.cmd_moveLinearStage.set(distanceFromHome=float(linear_stage))
+            setup_coroutines.append(self.atspectrograph.cmd_moveLinearStage.start(timeout=self.long_timeout))
 
         if len(setup_coroutines) > 0:
             async with self.cmd_lock:
                 return await asyncio.gather(*setup_coroutines)
+
+    async def close(self):
+        await asyncio.gather(*[self._remotes[r].close() for r in self._remotes])
+        await self.domain.close()
+
+    async def __aenter__(self):
+        await self.start_task
+        return self
+
+    async def __aexit__(self, *args):
+
+        await self.close()

--- a/python/lsst/ts/standardscripts/auxtel/mock/README.md
+++ b/python/lsst/ts/standardscripts/auxtel/mock/README.md
@@ -1,0 +1,4 @@
+
+This module contains mocks for the AuxTel high level systems that can be used
+for unit testings. They should mimic the overall behaviour expected of each
+system.

--- a/python/lsst/ts/standardscripts/auxtel/mock/__init__.py
+++ b/python/lsst/ts/standardscripts/auxtel/mock/__init__.py
@@ -1,0 +1,2 @@
+from .latiss_mock import *
+from .attcs_mock import *

--- a/python/lsst/ts/standardscripts/auxtel/mock/attcs_mock.py
+++ b/python/lsst/ts/standardscripts/auxtel/mock/attcs_mock.py
@@ -1,0 +1,296 @@
+
+__all__ = ["ATTCSMock"]
+
+import asyncio
+import numpy as np
+
+from lsst.ts import salobj
+from lsst.ts.idl.enums import ATDome
+
+LONG_TIMEOUT = 30
+
+
+class ATTCSMock:
+    """ Mock the behavior of the combined components that make out ATTCS.
+
+    This is useful for unit testing.
+
+    """
+    def __init__(self):
+
+        self._components = ["ATMCS", "ATPtg", "ATAOS", "ATPneumatics",
+                            "ATHexapod", "ATDome", "ATDomeTrajectory"]
+
+        self.components = [comp.lower() for comp in self._components]
+
+        # creating controllers for all components involved
+        self.atmcs = salobj.Controller("ATMCS")
+        self.atptg = salobj.Controller("ATPtg")
+        self.atdome = salobj.Controller("ATDome")
+        self.ataos = salobj.Controller("ATAOS")
+        self.atpneumatics = salobj.Controller("ATPneumatics")
+        self.athexapod = salobj.Controller("ATHexapod")
+        self.atdometrajectory = salobj.Controller("ATDomeTrajectory")
+
+        self.setting_versions = {}
+
+        self.settings_to_apply = {}
+
+        for comp in self.components:
+            getattr(self, comp).cmd_start.callback = self.get_start_callback(comp)
+            getattr(self, comp).cmd_enable.callback = self.get_enable_callback(comp)
+            getattr(self, comp).cmd_disable.callback = self.get_disable_callback(comp)
+            getattr(self, comp).cmd_standby.callback = self.get_standby_callback(comp)
+
+        self.atdome.cmd_moveShutterMainDoor.callback = self.move_shutter_callback
+        self.atdome.cmd_closeShutter.callback = self.close_shutter_callback
+        self.atpneumatics.cmd_openM1Cover.callback = self.generic_callback
+        self.atpneumatics.cmd_closeM1Cover.callback = self.generic_callback
+        self.ataos.cmd_enableCorrection.callback = self.generic_callback
+        self.ataos.cmd_disableCorrection.callback = self.generic_callback
+
+        self.dome_shutter_pos = 0.
+
+        self.slew_time = 10.
+
+        self.tel_alt = 80.
+        self.tel_az = 0.
+        self.dom_az = 0.
+
+        self.track = False
+
+        self.start_task_finished = False
+        self.start_task = asyncio.create_task(self.start_task_publish())
+
+        self.task_list = []
+
+        self.tel_pos_task = None
+        self.dome_pos_task = None
+        self.run_telemetry_loop = True
+
+        self.atptg.cmd_raDecTarget.callback = self.fake_slew_callback
+        self.atptg.cmd_azElTarget.callback = self.fake_slew_callback
+        self.atptg.cmd_planetTarget.callback = self.fake_slew_callback
+        self.atptg.cmd_stopTracking.callback = self.fake_stop_tracking
+
+        self.atdome.cmd_moveAzimuth.callback = self.fake_move_dome
+
+    async def start_task_publish(self):
+
+        if self.start_task_finished:
+            return
+
+        await asyncio.gather(self.atmcs.start_task,
+                             self.atptg.start_task,
+                             self.atdome.start_task,
+                             self.ataos.start_task,
+                             self.atpneumatics.start_task,
+                             self.athexapod.start_task,
+                             self.atdometrajectory.start_task)
+
+        for comp in self.components:
+            getattr(self, comp).evt_summaryState.set_put(summaryState=salobj.State.STANDBY)
+            self.setting_versions[comp] = f"test_{comp}"
+            getattr(self, comp).evt_settingVersions.set_put(
+                recommendedSettingsVersion=f"{self.setting_versions[comp]},"
+            )
+
+        self.atdome.evt_scbLink.set_put(active=True, force_output=True)
+        self.run_telemetry_loop = True
+        self.tel_pos_task = asyncio.create_task(self.fake_tel_pos_telemetry())
+        self.dome_pos_task = asyncio.create_task(self.dome_tel_pos_telemetry())
+
+        self.start_task_finished = True
+
+    async def fake_tel_pos_telemetry(self):
+        while self.run_telemetry_loop:
+
+            self.atmcs.tel_mount_AzEl_Encoders.set_put(
+                elevationCalculatedAngle=np.zeros(100)+self.tel_alt,
+                azimuthCalculatedAngle=np.zeros(100)+self.tel_az,
+            )
+
+            if self.track:
+                self.atmcs.evt_target.set_put(elevation=self.tel_alt,
+                                              azimuth=self.tel_az,
+                                              force_output=True)
+
+            await asyncio.sleep(1.)
+
+    async def dome_tel_pos_telemetry(self):
+        while self.run_telemetry_loop:
+            self.atdome.tel_position.set_put(azimuthPosition=self.dom_az)
+            await asyncio.sleep(1.)
+
+    async def atmcs_wait_and_fault(self, wait_time):
+        self.atmcs.evt_summaryState.set_put(summaryState=salobj.State.ENABLED,
+                                            force_output=True)
+        await asyncio.sleep(wait_time)
+        self.atmcs.evt_summaryState.set_put(summaryState=salobj.State.FAULT,
+                                            force_output=True)
+
+    async def atptg_wait_and_fault(self, wait_time):
+        self.atptg.evt_summaryState.set_put(summaryState=salobj.State.ENABLED,
+                                            force_output=True)
+        await asyncio.sleep(wait_time)
+        self.atptg.evt_summaryState.set_put(summaryState=salobj.State.FAULT,
+                                            force_output=True)
+
+    async def fake_slew_callback(self, id_data):
+        """Fake slew waits 5 seconds, then reports all axes
+           in position. Does not simulate the actual slew.
+        """
+        self.atmcs.evt_allAxesInPosition.set_put(inPosition=False,
+                                                 force_output=True)
+        self.atdome.evt_azimuthInPosition.set_put(inPosition=False,
+                                                  force_output=True)
+        self.track = True
+        self.task_list.append(asyncio.create_task(self.wait_and_send_inposition()))
+
+    async def fake_move_dome(self, data):
+        self.atdome.evt_azimuthInPosition.set_put(inPosition=False,
+                                                  force_output=True)
+
+        await asyncio.sleep(self.slew_time)
+
+        self.atdome.tel_position.set(azimuthPosition=data.azimuth)
+        self.atdome.evt_azimuthInPosition.set_put(inPosition=True,
+                                                  force_output=True)
+
+    async def fake_stop_tracking(self, data):
+        pass
+
+    async def wait_and_send_inposition(self):
+
+        await asyncio.sleep(self.slew_time)
+        self.atmcs.evt_allAxesInPosition.set_put(inPosition=True,
+                                                 force_output=True)
+        await asyncio.sleep(0.5)
+        self.atdome.evt_azimuthInPosition.set_put(inPosition=True,
+                                                  force_output=True)
+
+    async def generic_callback(self, id_data):
+        await asyncio.sleep(0.5)
+
+    async def move_shutter_callback(self, id_data):
+        # This command returns right away in the current version of the dome.
+        if id_data.open and self.dome_shutter_pos == 0.:
+            self.task_list.append(asyncio.create_task(self.fake_open_shutter()))
+        elif not id_data.open and self.dome_shutter_pos == 1.:
+            self.task_list.append(asyncio.create_task(self.fake_close_shutter()))
+        else:
+            raise RuntimeError(f"Cannot execute operation: {id_data.open} with dome "
+                               f"at {self.dome_shutter_pos}")
+
+    async def close_shutter_callback(self, id_data):
+        if self.dome_shutter_pos == 1.:
+            self.task_list.append(asyncio.create_task(self.fake_close_shutter()))
+        else:
+            raise RuntimeError(f"Cannot close dome with dome "
+                               f"at {self.dome_shutter_pos}")
+
+    async def fake_open_shutter(self):
+        self.atdome.evt_shutterInPosition.set_put(inPosition=False,
+                                                  force_output=True)
+        self.atdome.evt_mainDoorState.set_put(state=ATDome.ShutterDoorState.OPENING)
+        for self.dome_shutter_pos in np.linspace(0., 1., 10):
+            self.atdome.tel_position.set_put(mainDoorOpeningPercentage=self.dome_shutter_pos)
+            await asyncio.sleep(self.slew_time/10.)
+        self.atdome.evt_shutterInPosition.set_put(inPosition=True,
+                                                  force_output=True)
+        self.atdome.evt_mainDoorState.set_put(state=ATDome.ShutterDoorState.OPENED)
+
+    async def fake_close_shutter(self):
+        self.atdome.evt_shutterInPosition.set_put(inPosition=False,
+                                                  force_output=True)
+        self.atdome.evt_mainDoorState.set_put(state=ATDome.ShutterDoorState.CLOSING)
+        for self.dome_shutter_pos in np.linspace(1., 0., 10):
+            self.atdome.tel_position.set_put(mainDoorOpeningPercentage=self.dome_shutter_pos)
+            await asyncio.sleep(self.slew_time/10.)
+        self.atdome.evt_shutterInPosition.set_put(inPosition=True,
+                                                  force_output=True)
+        self.atdome.evt_mainDoorState.set_put(state=ATDome.ShutterDoorState.CLOSED)
+
+    def get_start_callback(self, comp):
+
+        def callback(id_data):
+
+            ss = getattr(self, comp).evt_summaryState.data.summaryState
+
+            if ss != salobj.State.STANDBY:
+                raise RuntimeError(f"Current state is {salobj.State(ss.summaryState)}.")
+
+            getattr(self, comp).evt_summaryState.set_put(summaryState=salobj.State.DISABLED)
+
+            self.settings_to_apply[comp] = id_data.settingsToApply
+
+        return callback
+
+    def get_enable_callback(self, comp):
+
+        def callback(id_data):
+            ss = getattr(self, comp).evt_summaryState.data.summaryState
+
+            if ss != salobj.State.DISABLED:
+                raise RuntimeError(f"Current state is {salobj.State(ss.summaryState)}.")
+
+            getattr(self, comp).evt_summaryState.set_put(summaryState=salobj.State.ENABLED)
+
+        return callback
+
+    def get_disable_callback(self, comp):
+
+        def callback(id_data):
+            ss = getattr(self, comp).evt_summaryState.data.summaryState
+
+            if ss != salobj.State.ENABLED:
+                raise RuntimeError(f"Current state is {salobj.State(ss.summaryState)}.")
+
+            getattr(self, comp).evt_summaryState.set_put(summaryState=salobj.State.DISABLED)
+
+        return callback
+
+    def get_standby_callback(self, comp):
+
+        def callback(id_data):
+            ss = getattr(self, comp).evt_summaryState.data.summaryState
+
+            if ss != salobj.State.DISABLED:
+                raise RuntimeError(f"Current state is {salobj.State(ss.summaryState)}.")
+
+            getattr(self, comp).evt_summaryState.set_put(summaryState=salobj.State.STANDBY)
+
+        return callback
+
+    async def close(self):
+
+        # await all tasks created during runtime
+
+        try:
+            await asyncio.wait_for(asyncio.gather(*self.task_list),
+                                   timeout=LONG_TIMEOUT)
+
+            self.run_telemetry_loop = False
+
+            await asyncio.gather(self.tel_pos_task,
+                                 self.dome_pos_task)
+
+        except Exception:
+            pass
+
+        close_task = []
+
+        for comp in self.components:
+            close_task.append(getattr(self, comp).close())
+
+        await asyncio.gather(*close_task)
+
+    async def __aenter__(self):
+
+        await self.start_task
+
+        return self
+
+    async def __aexit__(self, *args):
+
+        await self.close()

--- a/python/lsst/ts/standardscripts/auxtel/mock/latiss_mock.py
+++ b/python/lsst/ts/standardscripts/auxtel/mock/latiss_mock.py
@@ -6,10 +6,9 @@ from lsst.ts import salobj
 
 
 class LATISSMock:
-    """ Mock the behavior of the combined components that make out LATISS.
+    """Mock the behavior of the combined components that make out LATISS.
 
     This is useful for unit testing.
-
     """
     def __init__(self):
 

--- a/python/lsst/ts/standardscripts/auxtel/mock/latiss_mock.py
+++ b/python/lsst/ts/standardscripts/auxtel/mock/latiss_mock.py
@@ -1,0 +1,91 @@
+
+__all__ = ["LATISSMock"]
+
+import asyncio
+from lsst.ts import salobj
+
+
+class LATISSMock:
+    """ Mock the behavior of the combined components that make out LATISS.
+
+    This is useful for unit testing.
+
+    """
+    def __init__(self):
+
+        self.atcam = salobj.Controller(name="ATCamera")
+        self.atspec = salobj.Controller(name="ATSpectrograph")
+
+        self.atcam.cmd_takeImages.callback = self.cmd_take_images_callback
+        self.atspec.cmd_changeFilter.callback = self.cmd_changeFilter_callback
+        self.atspec.cmd_changeDisperser.callback = self.cmd_changeDisperser_callback
+        self.atspec.cmd_moveLinearStage.callback = self.cmd_moveLinearStage_callback
+
+        self.readout_time = 2.
+        self.shutter_time = 1.
+
+        self.nimages = 0
+        self.exptime_list = []
+
+        self.latiss_filter = None
+        self.latiss_grating = None
+        self.latiss_linear_stage = None
+
+        self.end_readout_task = None
+
+        self.start_task = asyncio.gather(self.atspec.start_task,
+                                         self.atcam.start_task)
+
+    async def cmd_take_images_callback(self, data):
+        """Emulate take image command."""
+        one_exp_time = data.expTime + self.readout_time
+        if data.shutter:
+            one_exp_time += self.shutter_time
+        await asyncio.sleep(one_exp_time*data.numImages)
+        self.end_readout_task = asyncio.create_task(self.end_readout(data))
+
+    async def end_readout(self, data):
+        """Wait `self.readout_time` and send endReadout event."""
+        await asyncio.sleep(self.readout_time)
+        self.atcam.evt_endReadout.put()
+        self.nimages += 1
+        self.exptime_list.append(data.expTime)
+
+    async def cmd_changeFilter_callback(self, data):
+        """Emulate change filter command"""
+        await asyncio.sleep(0.1)
+        self.atspec.evt_filterInPosition.put()
+        self.atspec.evt_reportedFilterPosition.put()
+        self.latiss_filter = data.filter
+
+    async def cmd_changeDisperser_callback(self, data):
+        """Emulate change filter command"""
+        await asyncio.sleep(0.1)
+        self.atspec.evt_disperserInPosition.put()
+        self.atspec.evt_reportedDisperserPosition.put()
+        self.latiss_grating = data.disperser
+
+    async def cmd_moveLinearStage_callback(self, data):
+        """Emulate change filter command"""
+        await asyncio.sleep(0.1)
+        self.atspec.evt_linearStageInPosition.put()
+        self.atspec.evt_reportedLinearStagePosition.put()
+        self.latiss_linear_stage = data.distanceFromHome
+
+    async def close(self):
+        if self.end_readout_task is not None:
+            try:
+                await asyncio.wait_for(self.end_readout_task,
+                                       timeout=self.readout_time*2.)
+            except Exception:
+                pass
+
+        await asyncio.gather(self.atcam.close(),
+                             self.atspec.close())
+
+    async def __aenter__(self):
+        await asyncio.gather(self.start_task)
+        return self
+
+    async def __aexit__(self, *args):
+        await asyncio.gather(self.close())

--- a/tests/auxtel/test_latiss.py
+++ b/tests/auxtel/test_latiss.py
@@ -19,10 +19,12 @@
 # You should have received a copy of the GNU General Public License
 
 import unittest
+import asynctest
 import asyncio
 
 from lsst.ts import salobj
 from lsst.ts.standardscripts.auxtel.latiss import LATISS
+from lsst.ts.standardscripts.auxtel.mock import LATISSMock
 
 index_gen = salobj.index_generator()
 
@@ -33,128 +35,67 @@ class Harness:
         self.test_index = next(index_gen)
         salobj.test_utils.set_random_lsst_dds_domain()
 
-        self.atcam = salobj.Controller(name="ATCamera")
-        self.atspec = salobj.Controller(name="ATSpectrograph")
-
-        self.domain = salobj.Domain()
-        self.latiss = LATISS(salobj.Remote(domain=self.atcam.domain, name="ATCamera"),
-                             salobj.Remote(domain=self.atspec.domain, name="ATSpectrograph"))
-
-        self.atcam.cmd_takeImages.callback = self.cmd_take_images_callback
-        self.atspec.cmd_changeFilter.callback = self.cmd_changeFilter_callback
-        self.atspec.cmd_changeDisperser.callback = self.cmd_changeDisperser_callback
-        self.atspec.cmd_moveLinearStage.callback = self.cmd_moveLinearStage_callback
-
-        self.readout_time = 2.
-        self.shutter_time = 1.
-
-        self.nimages = 0
-        self.exptime_list = []
-
-        self.latiss_filter = None
-        self.latiss_grating = None
-        self.latiss_linear_stage = None
-
-    async def cmd_take_images_callback(self, data):
-        """Emulate take image command."""
-        one_exp_time = data.expTime + self.readout_time
-        if data.shutter:
-            one_exp_time += self.shutter_time
-        await asyncio.sleep(one_exp_time*data.numImages)
-        self.atcam.evt_endReadout.put()
-        self.nimages += 1
-        self.exptime_list.append(data.expTime)
-
-    async def cmd_changeFilter_callback(self, data):
-        """Emulate change filter command"""
-        await asyncio.sleep(0.1)
-        self.atspec.evt_filterInPosition.put()
-        self.atspec.evt_reportedFilterPosition.put()
-        self.latiss_filter = data.filter
-
-    async def cmd_changeDisperser_callback(self, data):
-        """Emulate change filter command"""
-        await asyncio.sleep(0.1)
-        self.atspec.evt_disperserInPosition.put()
-        self.atspec.evt_reportedDisperserPosition.put()
-        self.latiss_grating = data.disperser
-
-    async def cmd_moveLinearStage_callback(self, data):
-        """Emulate change filter command"""
-        await asyncio.sleep(0.1)
-        self.atspec.evt_linearStageInPosition.put()
-        self.atspec.evt_reportedLinearStagePosition.put()
-        self.latiss_linear_stage = data.distanceFromHome
+        self.latiss_remote = LATISS(salobj.Domain())
+        self.latiss_mock = LATISSMock()
 
     async def __aenter__(self):
-        await asyncio.gather(self.latiss.atcam.start_task,
-                             self.latiss.atspec.start_task,
-                             self.atcam.start_task,
-                             self.atspec.start_task)
+        await asyncio.gather(self.latiss_remote.start_task,
+                             self.latiss_mock.start_task)
         return self
 
     async def __aexit__(self, *args):
-        await asyncio.gather(self.atcam.close(),
-                             self.atspec.close())
+        await asyncio.gather(self.latiss_mock.close(),
+                             self.latiss_remote.close())
 
 
-class TestLATISS(unittest.TestCase):
+class TestLATISS(asynctest.TestCase):
 
-    def test_take_bias(self):
-        async def doit():
-            async with Harness() as harness:
-                nbias = 10
-                await harness.latiss.take_bias(nbias=nbias)
-                self.assertEqual(harness.nimages, nbias)
-                self.assertEqual(len(harness.exptime_list), nbias)
-                for i in range(nbias):
-                    self.assertEqual(harness.exptime_list[i], 0.)
-                self.assertIsNone(harness.latiss_linear_stage)
-                self.assertIsNone(harness.latiss_grating)
-                self.assertIsNone(harness.latiss_filter)
+    async def test_take_bias(self):
+        async with Harness() as harness:
+            nbias = 10
+            await harness.latiss_remote.take_bias(nbias=nbias)
+            self.assertEqual(harness.latiss_mock.nimages, nbias)
+            self.assertEqual(len(harness.latiss_mock.exptime_list), nbias)
+            for i in range(nbias):
+                self.assertEqual(harness.latiss_mock.exptime_list[i], 0.)
+            self.assertIsNone(harness.latiss_mock.latiss_linear_stage)
+            self.assertIsNone(harness.latiss_mock.latiss_grating)
+            self.assertIsNone(harness.latiss_mock.latiss_filter)
 
-        asyncio.get_event_loop().run_until_complete(doit())
+    async def test_take_darks(self):
+        async with Harness() as harness:
+            ndarks = 10
+            exptime = 5.
+            await harness.latiss_remote.take_darks(ndarks=ndarks,
+                                                   exptime=exptime)
+            self.assertEqual(harness.latiss_mock.nimages, ndarks)
+            self.assertEqual(len(harness.latiss_mock.exptime_list), ndarks)
+            for i in range(ndarks):
+                self.assertEqual(harness.latiss_mock.exptime_list[i], exptime)
+            self.assertIsNone(harness.latiss_mock.latiss_linear_stage)
+            self.assertIsNone(harness.latiss_mock.latiss_grating)
+            self.assertIsNone(harness.latiss_mock.latiss_filter)
 
-    def test_take_darks(self):
-        async def doit():
-            async with Harness() as harness:
-                ndarks = 10
-                exptime = 5.
-                await harness.latiss.take_darks(ndarks=ndarks,
-                                                exptime=exptime)
-                self.assertEqual(harness.nimages, ndarks)
-                self.assertEqual(len(harness.exptime_list), ndarks)
-                for i in range(ndarks):
-                    self.assertEqual(harness.exptime_list[i], exptime)
-                self.assertIsNone(harness.latiss_linear_stage)
-                self.assertIsNone(harness.latiss_grating)
-                self.assertIsNone(harness.latiss_filter)
+    async def test_take_flats(self):
+        async with Harness() as harness:
+            nflats = 10
+            exptime = 5.
+            filter_id = 1
+            grating_id = 1
+            linear_stage = 100.
 
-        asyncio.get_event_loop().run_until_complete(doit())
-
-    def test_take_flats(self):
-        async def doit():
-            async with Harness() as harness:
-                nflats = 10
-                exptime = 5.
-                filter_id = 1
-                grating_id = 1
-                linear_stage = 100.
-
-                await harness.latiss.take_flats(nflats=nflats,
-                                                exptime=exptime,
-                                                filter=filter_id,
-                                                grating=grating_id,
-                                                linear_stage=linear_stage)
-                self.assertEqual(harness.nimages, nflats)
-                self.assertEqual(len(harness.exptime_list), nflats)
-                for i in range(nflats):
-                    self.assertEqual(harness.exptime_list[i], exptime)
-                self.assertEqual(harness.latiss_filter, filter_id)
-                self.assertEqual(harness.latiss_grating, grating_id)
-                self.assertEqual(harness.latiss_linear_stage, linear_stage)
-
-        asyncio.get_event_loop().run_until_complete(doit())
+            await harness.latiss_remote.take_flats(nflats=nflats,
+                                                   exptime=exptime,
+                                                   filter=filter_id,
+                                                   grating=grating_id,
+                                                   linear_stage=linear_stage)
+            self.assertEqual(harness.latiss_mock.nimages, nflats)
+            self.assertEqual(len(harness.latiss_mock.exptime_list), nflats)
+            for i in range(nflats):
+                self.assertEqual(harness.latiss_mock.exptime_list[i], exptime)
+            self.assertEqual(harness.latiss_mock.latiss_filter, filter_id)
+            self.assertEqual(harness.latiss_mock.latiss_grating, grating_id)
+            self.assertEqual(harness.latiss_mock.latiss_linear_stage, linear_stage)
 
 
 if __name__ == '__main__':

--- a/tests/test_attcs.py
+++ b/tests/test_attcs.py
@@ -1,13 +1,15 @@
-from lsst.ts.standardscripts.auxtel.attcs import ATTCS
+
 import unittest
+import asynctest
 import asyncio
-import numpy as np
 
 from lsst.ts import salobj
 from lsst.ts.salobj import test_utils
 from lsst.ts.idl.enums import ATPtg
 import logging
-# from math import isclose
+
+from lsst.ts.standardscripts.auxtel.attcs import ATTCS
+from lsst.ts.standardscripts.auxtel.mock import ATTCSMock
 
 logger = logging.getLogger()
 logger.level = logging.DEBUG
@@ -22,334 +24,159 @@ class Harness:
 
         test_utils.set_random_lsst_dds_domain()
 
-        self.atmcs = salobj.Controller("ATMCS")
-        self.atptg = salobj.Controller("ATPtg")
-        self.atdome = salobj.Controller("ATDome")
-        self.ataos = salobj.Controller("ATAOS")
-        self.atpneumatics = salobj.Controller("ATPneumatics")
-        self.athexapod = salobj.Controller("ATHexapod")
-        self.atdometrajectory = salobj.Controller("ATDomeTrajectory")
+        self.attcs_mock = ATTCSMock()
 
-        self.setting_versions = {}
-
-        self.settings_to_apply = {}
+        self.atmcs = self.attcs_mock.atmcs
+        self.atptg = self.attcs_mock.atptg
+        self.atdome = self.attcs_mock.atdome
+        self.ataos = self.attcs_mock.ataos
+        self.atpneumatics = self.attcs_mock.atpneumatics
+        self.athexapod = self.attcs_mock.athexapod
+        self.atdometrajectory = self.attcs_mock.atdometrajectory
 
         self.attcs = ATTCS(indexed_dome=False)
 
-        for comp in self.attcs.components:
-            getattr(self, comp).evt_summaryState.set_put(summaryState=salobj.State.STANDBY)
-            self.setting_versions[comp] = f"test_{comp}"
-            getattr(self, comp).evt_settingVersions.set_put(
-                recommendedSettingsVersion=f"{self.setting_versions[comp]},"
-            )
-            getattr(self, comp).cmd_start.callback = self.get_start_callback(comp)
-            getattr(self, comp).cmd_enable.callback = self.get_enable_callback(comp)
-            getattr(self, comp).cmd_disable.callback = self.get_disable_callback(comp)
-            getattr(self, comp).cmd_standby.callback = self.get_standby_callback(comp)
-
-        self.atdome.cmd_moveShutterMainDoor.callback = self.move_shutter_callback
-        self.atdome.cmd_closeShutter.callback = self.close_shutter_callback
-        self.atpneumatics.cmd_openM1Cover.callback = self.generic_callback
-        self.atpneumatics.cmd_closeM1Cover.callback = self.generic_callback
-        self.ataos.cmd_enableCorrection.callback = self.generic_callback
-        self.ataos.cmd_disableCorrection.callback = self.generic_callback
-
-        self.atdome.evt_scbLink.set_put(active=True, force_output=True)
-
-        self.dome_shutter_pos = 0.
-
-        self.slew_time = 10.
-
-        self.tel_alt = 80.
-        self.tel_az = 0.
-        self.dom_az = 0.
-
-        self.track = False
-
-        self.tel_pos_task = asyncio.ensure_future(self.fake_tel_pos_telemetry())
-        self.dome_pos_task = asyncio.ensure_future(self.dome_tel_pos_telemetry())
-        self.run_telemetry_loop = True
-
-        self.atptg.cmd_raDecTarget.callback = self.fake_slew_callback
-        self.atptg.cmd_planetTarget.callback = self.fake_slew_callback
-
-    async def fake_tel_pos_telemetry(self):
-        while self.run_telemetry_loop:
-
-            self.atmcs.tel_mount_AzEl_Encoders.set_put(
-                elevationCalculatedAngle=np.zeros(100)+self.tel_alt,
-                azimuthCalculatedAngle=np.zeros(100)+self.tel_az,
-            )
-
-            if self.track:
-                self.atmcs.evt_target.set_put(elevation=self.tel_alt,
-                                              azimuth=self.tel_az,
-                                              force_output=True)
-
-            await asyncio.sleep(1.)
-
-    async def dome_tel_pos_telemetry(self):
-        while self.run_telemetry_loop:
-            self.atdome.tel_position.set_put(azimuthPosition=self.dom_az)
-            await asyncio.sleep(1.)
-
-    async def atmcs_wait_and_fault(self, wait_time):
-        self.log.debug("atmcs ENABLED")
-        self.atmcs.evt_summaryState.set_put(summaryState=salobj.State.ENABLED,
-                                            force_output=True)
-        await asyncio.sleep(wait_time)
-        self.log.debug("atmcs FAULT")
-        self.atmcs.evt_summaryState.set_put(summaryState=salobj.State.FAULT,
-                                            force_output=True)
-
-    async def atptg_wait_and_fault(self, wait_time):
-        self.log.debug("atptg ENABLED")
-        self.atptg.evt_summaryState.set_put(summaryState=salobj.State.ENABLED,
-                                            force_output=True)
-        await asyncio.sleep(wait_time)
-        self.log.debug("atptg FAULT")
-        self.atptg.evt_summaryState.set_put(summaryState=salobj.State.FAULT,
-                                            force_output=True)
-
-    async def fake_slew_callback(self, id_data):
-        """Fake slew waits 5 seconds, then reports all axes
-           in position. Does not simulate the actual slew.
-        """
-        self.atmcs.evt_allAxesInPosition.set_put(inPosition=False,
-                                                 force_output=True)
-        self.atdome.evt_azimuthInPosition.set_put(inPosition=False,
-                                                  force_output=True)
-        self.track = True
-        asyncio.ensure_future(self.wait_and_send_inposition())
-
-    async def wait_and_send_inposition(self):
-
-        await asyncio.sleep(self.slew_time)
-        self.atmcs.evt_allAxesInPosition.set_put(inPosition=True,
-                                                 force_output=True)
-        await asyncio.sleep(0.5)
-        self.atdome.evt_azimuthInPosition.set_put(inPosition=True,
-                                                  force_output=True)
-
-    async def generic_callback(self, id_data):
-        await asyncio.sleep(0.5)
-
-    async def move_shutter_callback(self, id_data):
-        # This command returns right away in the current version of the dome.
-        if id_data.open and self.dome_shutter_pos == 0.:
-            asyncio.ensure_future(self.fake_open_shutter())
-        elif not id_data.open and self.dome_shutter_pos == 1.:
-            asyncio.ensure_future(self.fake_close_shutter())
-        else:
-            raise RuntimeError(f"Cannot execute operation: {id_data.open} with dome "
-                               f"at {self.dome_shutter_pos}")
-
-    async def close_shutter_callback(self, id_data):
-        if self.dome_shutter_pos == 1.:
-            asyncio.ensure_future(self.fake_close_shutter())
-        else:
-            raise RuntimeError(f"Cannot close dome with dome "
-                               f"at {self.dome_shutter_pos}")
-
-    async def fake_open_shutter(self):
-        self.atdome.evt_shutterInPosition.set_put(inPosition=False,
-                                                  force_output=True)
-        for self.dome_shutter_pos in np.linspace(0., 1., 10):
-            self.atdome.tel_position.set_put(mainDoorOpeningPercentage=self.dome_shutter_pos)
-            await asyncio.sleep(self.slew_time/10.)
-        self.atdome.evt_shutterInPosition.set_put(inPosition=True,
-                                                  force_output=True)
-
-    async def fake_close_shutter(self):
-        self.atdome.evt_shutterInPosition.set_put(inPosition=False,
-                                                  force_output=True)
-        for self.dome_shutter_pos in np.linspace(1., 0., 10):
-            self.atdome.tel_position.set_put(mainDoorOpeningPercentage=self.dome_shutter_pos)
-            await asyncio.sleep(self.slew_time/10.)
-        self.atdome.evt_shutterInPosition.set_put(inPosition=True,
-                                                  force_output=True)
-
-    def get_start_callback(self, comp):
-
-        def callback(id_data):
-
-            ss = getattr(self, comp).evt_summaryState.data.summaryState
-
-            if ss != salobj.State.STANDBY:
-                raise RuntimeError(f"Current state is {salobj.State(ss.summaryState)}.")
-
-            getattr(self, comp).evt_summaryState.set_put(summaryState=salobj.State.DISABLED)
-
-            self.settings_to_apply[comp] = id_data.settingsToApply
-
-        return callback
-
-    def get_enable_callback(self, comp):
-
-        def callback(id_data):
-            ss = getattr(self, comp).evt_summaryState.data.summaryState
-
-            if ss != salobj.State.DISABLED:
-                raise RuntimeError(f"Current state is {salobj.State(ss.summaryState)}.")
-
-            getattr(self, comp).evt_summaryState.set_put(summaryState=salobj.State.ENABLED)
-
-        return callback
-
-    def get_disable_callback(self, comp):
-
-        def callback(id_data):
-            ss = getattr(self, comp).evt_summaryState.data.summaryState
-
-            if ss != salobj.State.ENABLED:
-                raise RuntimeError(f"Current state is {salobj.State(ss.summaryState)}.")
-
-            getattr(self, comp).evt_summaryState.set_put(summaryState=salobj.State.DISABLED)
-
-        return callback
-
-    def get_standby_callback(self, comp):
-
-        def callback(id_data):
-            ss = getattr(self, comp).evt_summaryState.data.summaryState
-
-            if ss != salobj.State.DISABLED:
-                raise RuntimeError(f"Current state is {salobj.State(ss.summaryState)}.")
-
-            getattr(self, comp).evt_summaryState.set_put(summaryState=salobj.State.STANDBY)
-
-        return callback
-
     async def __aenter__(self):
 
-        start_task = [self.attcs.start_task]
-
-        for comp in self.attcs.components:
-            start_task.append(getattr(self, comp).start_task)
-
-        await asyncio.gather(*start_task)
+        await asyncio.gather(self.attcs.start_task, self.attcs_mock.start_task)
 
         return self
 
     async def __aexit__(self, *args):
-        self.run_telemetry_loop = False
 
-        close_task = [self.tel_pos_task,
-                      self.dome_pos_task,
-                      self.attcs.close()]
-
-        for comp in self.attcs.components:
-            close_task.append(getattr(self, comp).close())
-
-        await asyncio.gather(*close_task)
+        await asyncio.gather(self.attcs.close(),
+                             self.attcs_mock.close())
 
 
-class TestATTCS(unittest.TestCase):
+class TestATTCS(asynctest.TestCase):
 
-    def test_slew(self):
+    async def test_slew(self):
 
-        async def runtest():
+        async with Harness() as harness:
 
-            async with Harness() as harness:
+            await harness.attcs.startup()
 
-                ra = 0.
-                dec = -30.
+            ra = 0.
+            dec = -30.
 
-                harness.log.debug("test 1 start")
+            harness.log.debug("test 1 start")
 
-                with self.subTest(ra=ra, dec=dec):
-                    await harness.attcs.slew(ra, dec, slew_timeout=harness.slew_time*2.)
+            with self.subTest(ra=ra, dec=dec):
+                await harness.attcs.slew(ra, dec, slew_timeout=harness.attcs_mock.slew_time*2.)
 
-                harness.log.debug("test 2 start")
+            harness.log.debug("test 2 start")
 
-                with self.subTest(msg="Ra/Dec: Fail ATPtg FAULT", component="ATPtg"):
-                    with self.assertRaises(RuntimeError):
-                        ret_val = await asyncio.gather(
-                            harness.attcs.slew(ra, dec,
-                                               slew_timeout=harness.slew_time*2.),
-                            harness.atptg_wait_and_fault(1.),
-                            return_exceptions=True)
-                        for val in ret_val:
-                            harness.log.debug(f"retval: {val!r}")
+            with self.subTest(msg="Ra/Dec: Fail ATPtg FAULT", component="ATPtg"):
+                with self.assertRaises(RuntimeError):
+                    ret_val = await asyncio.gather(
+                        harness.attcs.slew(ra, dec,
+                                           slew_timeout=harness.attcs_mock.slew_time*2.),
+                        harness.attcs_mock.atptg_wait_and_fault(1.),
+                        return_exceptions=True)
+                    for val in ret_val:
+                        harness.log.debug(f"retval: {val!r}")
 
-                        for val in ret_val:
-                            if isinstance(val, Exception):
-                                raise val
+                    for val in ret_val:
+                        if isinstance(val, Exception):
+                            raise val
 
-                harness.log.debug("test 3 start")
+            harness.log.debug("test 3 start")
 
-                with self.subTest(msg="Ra/Dec: Fail ATMCS FAULT", component="ATMCS"):
-                    with self.assertRaises(RuntimeError):
+            with self.subTest(msg="Ra/Dec: Fail ATMCS FAULT", component="ATMCS"):
+                with self.assertRaises(RuntimeError):
 
-                        ret_val = await asyncio.gather(
-                            harness.attcs.slew(ra, dec, slew_timeout=harness.slew_time*2.),
-                            harness.atmcs_wait_and_fault(1.),
-                            return_exceptions=True)
+                    ret_val = await asyncio.gather(
+                        harness.attcs.slew(ra, dec, slew_timeout=harness.attcs_mock.slew_time*2.),
+                        harness.attcs_mock.atmcs_wait_and_fault(1.),
+                        return_exceptions=True)
 
-                        for val in ret_val:
-                            harness.log.debug(f"retval: {val!r}")
+                    for val in ret_val:
+                        harness.log.debug(f"retval: {val!r}")
 
-                        for val in ret_val:
-                            if isinstance(val, Exception):
-                                raise val
+                    for val in ret_val:
+                        if isinstance(val, Exception):
+                            raise val
 
-                harness.log.debug("test 4 start")
+            harness.log.debug("test 4 start")
 
-                for planet in ATPtg.Planets:
-                    with self.subTest(planet=planet):
-                        await harness.attcs.slew_to_planet(planet,
-                                                           slew_timeout=harness.slew_time*2.)
+            for planet in ATPtg.Planets:
+                with self.subTest(planet=planet):
+                    await harness.attcs.slew_to_planet(planet,
+                                                       slew_timeout=harness.attcs_mock.slew_time*2.)
 
-                harness.log.debug("test 5 start")
+            harness.log.debug("test 5 start")
 
-                with self.subTest(msg="Planet: Fail ATMCS FAULT", component="ATMCS"):
-                    with self.assertRaises(RuntimeError):
-                        ret_val = await asyncio.gather(
-                            harness.attcs.slew_to_planet(
-                                ATPtg.Planets.JUPITER,
-                                slew_timeout=harness.slew_time*2.),
-                            harness.atmcs_wait_and_fault(1.),
-                            return_exceptions=True)
-                        for val in ret_val:
-                            if isinstance(val, Exception):
-                                raise val
-                            else:
-                                harness.log.debug(f"ret_val: {val}")
+            with self.subTest(msg="Planet: Fail ATMCS FAULT", component="ATMCS"):
+                with self.assertRaises(RuntimeError):
+                    ret_val = await asyncio.gather(
+                        harness.attcs.slew_to_planet(
+                            ATPtg.Planets.JUPITER,
+                            slew_timeout=harness.attcs_mock.slew_time*2.),
+                        harness.attcs_mock.atmcs_wait_and_fault(1.),
+                        return_exceptions=True)
+                    for val in ret_val:
+                        if isinstance(val, Exception):
+                            raise val
+                        else:
+                            harness.log.debug(f"ret_val: {val}")
 
-                harness.log.debug("test 6 start")
+            harness.log.debug("test 6 start")
 
-                with self.subTest(msg="Planet: Fail ATPtg FAULT", component="ATPtg"):
-                    with self.assertRaises(RuntimeError):
-                        ret_val = await asyncio.gather(
-                            harness.attcs.slew_to_planet(
-                                ATPtg.Planets.JUPITER,
-                                slew_timeout=harness.slew_time*2.),
-                            harness.atptg_wait_and_fault(1.),
-                            return_exceptions=True)
-                        for val in ret_val:
-                            if isinstance(val, Exception):
-                                raise val
-                            else:
-                                harness.log.debug(f"ret_val: {val}")
+            with self.subTest(msg="Planet: Fail ATPtg FAULT", component="ATPtg"):
+                with self.assertRaises(RuntimeError):
+                    ret_val = await asyncio.gather(
+                        harness.attcs.slew_to_planet(
+                            ATPtg.Planets.JUPITER,
+                            slew_timeout=harness.attcs_mock.slew_time*2.),
+                        harness.attcs_mock.atptg_wait_and_fault(1.),
+                        return_exceptions=True)
+                    for val in ret_val:
+                        if isinstance(val, Exception):
+                            raise val
+                        else:
+                            harness.log.debug(f"ret_val: {val}")
 
-                harness.log.debug("test done")
+            harness.log.debug("test done")
 
-        asyncio.get_event_loop().run_until_complete(runtest())
+    async def test_startup_shutdown(self):
 
-    def test_startup_shutdown(self):
+        async with Harness() as harness:
 
-        async def runtest():
+            # Testing when passing settings for all components
 
-            async with Harness() as harness:
+            settings = dict(zip(harness.attcs.components,
+                                [f'setting4_{c}' for c in harness.attcs.components]))
 
-                settings = dict(zip(harness.attcs.components,
-                                    [f'setting4_{c}' for c in harness.attcs.components]))
+            await harness.attcs.startup(settings)
 
-                await harness.attcs.startup(settings)
+            for comp in settings:
+                self.assertEqual(harness.attcs_mock.settings_to_apply[comp],
+                                 settings[comp])
 
-                await harness.attcs.shutdown()
+            await harness.attcs.shutdown()
 
-        asyncio.get_event_loop().run_until_complete(runtest())
+            # Testing when not passing settings for all components and only
+            # atdome and ataos sent evt_settingVersions.
+            # atdome sent a single label but ataos sends more then one.
+
+            harness.atdome.evt_settingVersions.set_put(
+                recommendedSettingsLabels="setting4_atdome_set")
+
+            harness.ataos.evt_settingVersions.set_put(
+                recommendedSettingsLabels="setting4_ataos_set1,setting4_ataos2_set2")
+
+            await harness.attcs.startup()
+
+            for comp in harness.attcs.components:
+                if comp == "atdome":
+                    self.assertEqual(harness.attcs_mock.settings_to_apply[comp],
+                                     "setting4_atdome_set")
+                elif comp == "ataos":
+                    self.assertEqual(harness.attcs_mock.settings_to_apply[comp],
+                                     "setting4_ataos_set1")
+                else:
+                    self.assertEqual(harness.attcs_mock.settings_to_apply[comp],
+                                     "")
 
 
 if __name__ == '__main__':

--- a/tests/test_attcs.py
+++ b/tests/test_attcs.py
@@ -165,6 +165,9 @@ class TestATTCS(asynctest.TestCase):
             harness.ataos.evt_settingVersions.set_put(
                 recommendedSettingsLabels="setting4_ataos_set1,setting4_ataos2_set2")
 
+            # Give remotes some time to update their data.
+            await asyncio.sleep(harness.attcs.fast_timeout)
+
             await harness.attcs.startup()
 
             for comp in harness.attcs.components:


### PR DESCRIPTION
Make ATTCS and LATISS class interfaces more uniform.
Include mock controllers for ATTCS and LATISS
Improve ATTCS and LATISS unit test.
Update Jenkisfile
Implement a way to skip components in startup procedure.
Add method to send telescope to flat field position.
Add some improvements to shutdown procedure.
Implement `point_azel` and point telescope and dome to park position in shutdown.