### PR TITLE
Lock black version to 19.10b0

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -26,7 +26,7 @@ test:
     - pytest-cov
     - asynctest
     - pytest-tornasync
-    - black
+    - black == 19.10b0
     - numpy
     - astropy
     - astroquery

--- a/python/lsst/ts/standardscripts/base_track_target.py
+++ b/python/lsst/ts/standardscripts/base_track_target.py
@@ -67,7 +67,7 @@ class BaseTrackTarget(salobj.BaseScript, metaclass=abc.ABCMeta):
 
     @classmethod
     def get_schema(cls):
-        schema_yaml = f"""
+        schema_yaml = """
             $schema: http://json-schema.org/draft-07/schema#
             $id: https://github.com/lsst-ts/ts_standardscripts/base_slew.yaml
             title: BaseSlew v1


### PR DESCRIPTION
Remove unnecessary f-string on base_track_target.