### PR TITLE
DM-26770: Fix set_summary_state script and add a script to run any command to a CSC.

### DIFF
--- a/python/lsst/ts/standardscripts/run_command.py
+++ b/python/lsst/ts/standardscripts/run_command.py
@@ -1,0 +1,181 @@
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+__all__ = ["RunCommand"]
+
+import yaml
+
+from lsst.ts import salobj
+
+
+class RunCommand(salobj.BaseScript):
+    """Run a command from a CSC and, optionally, wait for an event once the
+    command finishes.
+
+    Notes
+    -----
+    **Checkpoints**
+
+    * "run {csc_name}:{index}:{cmd}" before commanding a CSC.
+
+    * "wait {csc_name}:{index}:{event}" after commanding a CSC and before
+      waiting for the event.
+
+    **Details**
+
+    * Dynamically loads IDL files as needed.
+    """
+
+    def __init__(self, index):
+        super().__init__(index=index, descr="Run command from CSC.")
+
+        # approximate time to construct a Remote for a CSC (sec)
+        self.create_remote_time = 15
+
+    @classmethod
+    def get_schema(cls):
+        schema_yaml = """
+            $schema: http://json-schema.org/draft-07/schema#
+            $id: https://github.com/lsst-ts/ts_standardscripts/RunCommand.yaml
+            title: RunCommand v1
+            description: Configuration for RunCommand.
+            type: object
+            properties:
+              component:
+                description: Name of the CSC to run command, format is
+                    CSC_name[:index]; the default index is 0.
+                type: string
+              cmd:
+                description: Name of the command to run.
+                type: string
+              event:
+                description: >-
+                    Name of the event to wait after the command is sent.
+                type: string
+              flush:
+                description: Flush event before sending command?
+                type: boolean
+                default: True
+              event_timeout:
+                description: Timeout (seconds) to wait for the event to arrive.
+                type: number
+                default: 30
+              parameters:
+                description: Parameters for the command.
+                type: object
+                properties:
+                  timeout:
+                    description: Timeout (seconds) to wait for the command to complete.
+                    type: number
+                    default: 30
+                additionalProperties: true
+            required: [component, cmd]
+            additionalProperties: false
+        """
+        return yaml.safe_load(schema_yaml)
+
+    async def configure(self, config):
+        """Configure the script.
+
+        Specify the CSCs to command, the command to run, the parameters for
+        the command. Optionally, specify an event to wait and if the event
+        should be flushed before sending the command.
+
+        Parameters
+        ----------
+        config : `types.SimpleNamespace`
+
+        Raises
+        ------
+        RuntimeError:
+            If `config.command` is not a valid command from the CSC.
+
+        """
+        self.log.info("Configure started")
+
+        self.config = config
+
+        self.name, self.index = salobj.name_to_name_index(config.component)
+        self.event = config.event if hasattr(config, "event") else None
+
+        self.remote = salobj.Remote(
+            domain=self.domain,
+            name=self.name,
+            index=self.index,
+            include=[self.event] if self.event is not None else [],
+        )
+
+        if config.cmd in self.remote.salinfo.command_names:
+            self.cmd = config.cmd
+        else:
+            raise RuntimeError(
+                f"Command {config.cmd} not a valid command for {self.name}."
+            )
+
+        getattr(self.remote, f"cmd_{self.cmd}").set(
+            **dict(
+                [(k, config.parameters[k]) for k in config.parameters if k != "timeout"]
+            )
+        )
+
+        self.flush = config.flush if self.event is not None else False
+
+        if self.event is not None and self.event not in self.remote.salinfo.event_names:
+            raise RuntimeError(f"Event {self.event} not a valid event for {self.name}.")
+
+    def set_metadata(self, metadata):
+        """Compute estimated duration.
+
+        Parameters
+        ----------
+        metadata : `Script_logevent_metadata`
+
+        """
+        # a crude estimate using command and event timeouts.
+        metadata.duration = (
+            self.config.parameters["timeout"] + self.config.event_timeout
+            if self.flush
+            else 0.0
+        )
+
+    async def run(self):
+        """Run script."""
+
+        if not self.remote.start_task.done():
+            self.log.debug("Waiting for remote start_task to complete.")
+            await self.remote.start_task
+
+        if self.flush:
+            getattr(self.remote, f"evt_{self.event}").flush()
+
+        await self.checkpoint(f"run {self.name}:{self.index}:{self.cmd}")
+
+        await getattr(self.remote, f"cmd_{self.cmd}").start(
+            timeout=self.config.parameters["timeout"]
+        )
+
+        if self.event is not None:
+            await self.checkpoint(f"wait {self.name}:{self.index}:{self.event}")
+
+            evt = await getattr(self.remote, f"evt_{self.event}").next(
+                flush=False, timeout=self.config.event_timeout
+            )
+
+            self.log.info(evt)

--- a/python/lsst/ts/standardscripts/set_summary_state.py
+++ b/python/lsst/ts/standardscripts/set_summary_state.py
@@ -21,7 +21,6 @@
 __all__ = ["SetSummaryState"]
 
 import asyncio
-import re
 
 import yaml
 
@@ -130,11 +129,7 @@ class SetSummaryState(salobj.BaseScript):
         # parse the data
         nameind_state_settings = []
         for elt in config.data:
-            match = re.match(r"(?P<name>[a-zA-Z_-]+)(:(?P<index>\d+))?$", elt[0])
-            if not match:
-                raise ValueError(f"{elt}[0] is not of the form CSC_name:index")
-            name = match["name"]
-            index = 0 if match["index"] is None else int(match["index"])
+            name, index = salobj.name_to_name_index(elt[0])
             state_name = elt[1]
             if not isinstance(state_name, str):
                 raise ValueError(f"{elt} summary state {state_name!r} is not a string")

--- a/python/lsst/ts/standardscripts/utils.py
+++ b/python/lsst/ts/standardscripts/utils.py
@@ -30,6 +30,7 @@ def get_scripts_dir():
     -------
     scripts_dir : `pathlib.Path`
         Absolute path to the specified scripts directory.
+
     """
     # 4 for python/lsst/ts/standardscripts
     return pathlib.Path(__file__).resolve().parents[4] / "scripts"

--- a/scripts/run_command.py
+++ b/scripts/run_command.py
@@ -1,4 +1,5 @@
-# This file is part of ts_standardscripts.
+#!/usr/bin/env python
+# This file is part of ts_standardscripts
 #
 # Developed for the LSST Telescope and Site Systems.
 # This product includes software developed by the LSST Project
@@ -17,17 +18,9 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from .utils import *
-from .set_summary_state import *
-from .run_command import *
-from .base_script_test_case import *
+import asyncio
 
-try:
-    from .version import *
-except ImportError:
-    __version__ = "?"
-    __repo_version__ = "?"
-    __fingerprint__ = "? *"
-    __dependency_versions__ = {}
+from lsst.ts.standardscripts import RunCommand
+
+asyncio.run(RunCommand.amain())

--- a/tests/test_maintel_track_target.py
+++ b/tests/test_maintel_track_target.py
@@ -74,9 +74,9 @@ class TestMTSlew(standardscripts.BaseScriptTestCase, asynctest.TestCase):
             with self.assertRaises(salobj.ExpectedError):
                 await self.configure_script(ra=1.0, dec=90.1)
 
-            # Invalid rot_strategy
+            # Invalid rot_type
             with self.assertRaises(salobj.ExpectedError):
-                await self.configure_script(ra=1.0, dec=-10.0, rot_strategy="invalid")
+                await self.configure_script(ra=1.0, dec=-10.0, rot_type="invalid")
 
             # Script can be configured with target name only
             await self.configure_script(target_name="eta Car")
@@ -85,12 +85,10 @@ class TestMTSlew(standardscripts.BaseScriptTestCase, asynctest.TestCase):
             await self.configure_script(ra=1.0, dec=-10.0)
 
             # Configure passing rotator angle and all rotator strategies
-            for rot_strategy in RotType:
-                with self.subTest(
-                    f"rot_strategy={rot_strategy.name}", rot_strategy=rot_strategy.name
-                ):
+            for rot_type in RotType:
+                with self.subTest(f"rot_type={rot_type.name}", rot_type=rot_type.name):
                     await self.configure_script(
-                        ra=1.0, dec=-10.0, rot_value=10, rot_strategy=rot_strategy.name
+                        ra=1.0, dec=-10.0, rot_value=10, rot_type=rot_type.name
                     )
 
             # Test ignore feature.

--- a/tests/test_run_command.py
+++ b/tests/test_run_command.py
@@ -1,0 +1,137 @@
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+import random
+import unittest
+
+import asynctest
+
+from lsst.ts import salobj
+from lsst.ts import standardscripts
+
+random.seed(47)  # for set_random_lsst_dds_domain
+
+
+class TestRunCommand(standardscripts.BaseScriptTestCase, asynctest.TestCase):
+    async def basic_make_script(self, index):
+        self.script = standardscripts.RunCommand(index=index)
+        self.controller = salobj.Controller("Test", index=1)
+        self.controller.cmd_setScalars.callback = self.set_scalars_callback
+        return [self.script, self.controller]
+
+    async def set_scalars_callback(self, data):
+        self.controller.evt_scalars.set_put(float0=data.float0, string0=data.string0)
+
+    async def test_configure_errors(self):
+        """Test error handling in the do_configure method.
+        """
+        async with self.make_script():
+            for bad_config in (
+                {},  # need component name and command name
+                {"component": "Test:1"},  # need command name
+                {"cmd": "setScalars"},  # need component name
+            ):
+                with self.subTest(bad_config=bad_config):
+                    with self.assertRaises(salobj.ExpectedError):
+                        await self.configure_script(**bad_config)
+
+    async def test_configure_good(self):
+        """Test the configure method with a valid configuration.
+        """
+        async with self.make_script():
+
+            # Basic providing only component and command
+            await self.configure_script(component="Test:1", cmd="setScalars")
+
+            self.assertEqual(self.script.name, "Test")
+            self.assertEqual(self.script.index, 1)
+            self.assertEqual(self.script.cmd, "setScalars")
+            self.assertIsNone(self.script.event)
+            self.assertFalse(self.script.flush)
+
+            # Provide event
+            await self.configure_script(
+                component="Test:1", cmd="setScalars", event="scalars"
+            )
+
+            self.assertEqual(self.script.name, "Test")
+            self.assertEqual(self.script.index, 1)
+            self.assertEqual(self.script.cmd, "setScalars")
+            self.assertEqual(self.script.event, "scalars")
+            self.assertTrue(self.script.flush)
+
+            # Provide event with flush = False
+            await self.configure_script(
+                component="Test:1", cmd="setScalars", event="scalars", flush=False
+            )
+
+            self.assertEqual(self.script.name, "Test")
+            self.assertEqual(self.script.index, 1)
+            self.assertEqual(self.script.cmd, "setScalars")
+            self.assertEqual(self.script.event, "scalars")
+            self.assertFalse(self.script.flush)
+
+            # Provide parameter for the command
+            await self.configure_script(
+                component="Test:1",
+                cmd="setScalars",
+                event="scalars",
+                parameters={"float0": 1.2345, "string0": "12345"},
+            )
+
+            self.assertEqual(self.script.name, "Test")
+            self.assertEqual(self.script.index, 1)
+            self.assertEqual(self.script.cmd, "setScalars")
+            self.assertEqual(self.script.event, "scalars")
+            self.assertTrue(self.script.flush)
+            self.assertAlmostEqual(
+                self.script.remote.cmd_setScalars.data.float0, 1.2345, places=5
+            )
+            self.assertEqual(self.script.remote.cmd_setScalars.data.string0, "12345")
+
+    async def test_run(self):
+        """Run test with Test component.
+        """
+
+        async with self.make_script():
+
+            # Provide parameter for the command
+            await self.configure_script(
+                component="Test:1",
+                cmd="setScalars",
+                event="scalars",
+                parameters={"float0": 1.2345, "string0": "12345"},
+            )
+
+            await self.run_script()
+
+            self.assertAlmostEqual(
+                self.controller.evt_scalars.data.float0, 1.2345, places=5
+            )
+            self.assertEqual(self.controller.evt_scalars.data.string0, "12345")
+
+    async def test_executable(self):
+        scripts_dir = standardscripts.get_scripts_dir()
+        script_path = scripts_dir / "set_summary_state.py"
+        await self.check_executable(script_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Move CSC parsing code in set_summary_state to utils, fix issue with regular expression that cause it to fails with components that had numbers in their name, e.g.; MTM2 and MTM1M3.
Add new script RunCommand, that allows one to run any command from a CSC and (optionally) wait for an event.
Add new option on BaseTrackTarget to “track target” for a specified duration. This allows us to mimic a visit with exposure.