### PR TITLE
Tickets/dm 34116

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,27 @@
 Version History
 ===============
 
+v1.11.0
+-------
+
+* In ``auxtel/track_target_and_take_image`` implement taking data with n>1.
+* Fix ``tests/test_auxtel_detector_characterization_std_flat_dataset.py`` to take into account snaps.
+* In ``auxtel/track_target_and_take_image`` script, implement a rotator flipping routine.
+  First it will try to slew the telescope with the provided rotation angle, if that doesn't work, flip 180 degrees and try again.
+* Add unit tests for the load snapshot scheduler scripts.
+* Add unit tests for the stop scheduler scripts.
+* Add unit tests for the resume scheduler scripts.
+* Add unit tests for the standby scheduler scripts.
+* Add unit tests for the enable scheduler scripts.
+* Add executables for the main telescope scheduler operational scripts.
+* Add executables for the auxiliary telescope scheduler operational scripts.
+* Add scheduler operations scripts for the Main Telescope.
+* Add scheduler operations scripts for the Auxiliary Telescope.
+* Add test utilities for the scheduler operational scripts.
+* Add scheduler submodule with base scripts for operating the Scheduler.
+  These are generic implementations that can be used for both the AT and MT schedulers.
+* Update setup.cfg to specify async_mode for pytest.
+    
 v1.10.1
 -------
 

--- a/python/lsst/ts/standardscripts/auxtel/track_target_and_take_image.py
+++ b/python/lsst/ts/standardscripts/auxtel/track_target_and_take_image.py
@@ -160,18 +160,60 @@ additionalProperties: false
     async def _take_data(self):
         """Take data."""
 
-        for exptime, grating, band_filter in zip(
-            self.config.exp_times, self.grating, self.band_filter
-        ):
+        if self.is_standard_visit():
+            self.log.debug(
+                f"Same instrument setup for all images. using n={len(self.config.exp_times)}."
+            )
+            # Note that we are not passing the filter and grating information
+            # take_object, this is handled in track_target_and_setup_instrument
+            # concurrently to slewing to the target. Since all exposures have
+            # the same configuration, we don't need to set them here again.
             await self.latiss.take_object(
-                exptime=exptime,
+                exptime=self.config.exp_times[0],
+                n=len(self.config.exp_times),
                 group_id=self.group_id,
-                filter=f"{self.config.filter_prefix}{band_filter}",
-                grating=grating,
                 reason=self.config.reason,
                 program=self.config.program,
             )
 
+        else:
+            self.log.debug(
+                "Different instrument setup for images. Taking one at a time."
+            )
+
+            for exptime, grating, band_filter in zip(
+                self.config.exp_times, self.grating, self.band_filter
+            ):
+                await self.latiss.take_object(
+                    exptime=exptime,
+                    n=1,
+                    group_id=self.group_id,
+                    filter=f"{self.config.filter_prefix}{band_filter}",
+                    grating=grating,
+                    reason=self.config.reason,
+                    program=self.config.program,
+                )
+
     async def stop_tracking(self):
         """Execute stop_tracking command on ATCS."""
         await self.atcs.stop_tracking()
+
+    def is_standard_visit(self) -> bool:
+        """Determine if script configuration specify a standard visit or a
+        set of observations with different configurations.
+
+        A standard visit consists of a sequence of images with the
+        same instrument configuration and exposure time.
+
+        Returns
+        -------
+        bool
+            True if instrument configuration and exposure time is the same for
+            all exposures.
+        """
+        return all(
+            [
+                len(set(item)) == 1
+                for item in (self.config.exp_times, self.grating, self.band_filter)
+            ]
+        )

--- a/python/lsst/ts/standardscripts/scheduler/__init__.py
+++ b/python/lsst/ts/standardscripts/scheduler/__init__.py
@@ -1,0 +1,22 @@
+# This file is part of ts_standardscripts.
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from .set_desired_state import *

--- a/python/lsst/ts/standardscripts/scheduler/enable.py
+++ b/python/lsst/ts/standardscripts/scheduler/enable.py
@@ -1,0 +1,83 @@
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+__all__ = ["Enable"]
+
+import types
+import typing
+
+import yaml
+
+from lsst.ts import salobj
+from lsst.ts.idl.enums.Scheduler import SalIndex
+
+from .set_desired_state import SetDesiredState
+
+
+class Enable(SetDesiredState):
+    """A base script that implements enable functionality for the Scheduler.
+
+    Parameters
+    ----------
+    index : `int`
+        Index of Script SAL component.
+    scheduler_index : `int`
+        Index of the Scheduler to enable.
+    """
+
+    def __init__(self, index: int, scheduler_index: SalIndex) -> None:
+        super().__init__(
+            index=index,
+            descr=f"Enable {scheduler_index.name} Scheduler",
+            scheduler_index=scheduler_index,
+            desired_state=salobj.State.ENABLED,
+        )
+
+    @classmethod
+    def get_schema(cls) -> typing.Optional[typing.Dict[str, typing.Any]]:
+        return yaml.safe_load(
+            """
+$schema: http://json-schema.org/draft-07/schema#
+$id: https://github.com/lsst-ts/ts_standardscripts/scheduler/base_enable.py
+title: BaseEnable v1
+description: Configuration for enable scheduler.
+type: object
+properties:
+    config:
+        description: Scheduler configuration.
+        type: string
+required:
+    - config
+additionalProperties: false
+        """
+        )
+
+    async def configure(self, config: types.SimpleNamespace) -> None:
+        """Configure the script.
+
+        Parameters
+        ----------
+        config : `types.SimpleNamespace`
+            Configuration.
+        """
+
+        self.log.info(f"Scheduler configuration: {config.config}")
+
+        self.configuration = config.config

--- a/python/lsst/ts/standardscripts/scheduler/load_snapshot.py
+++ b/python/lsst/ts/standardscripts/scheduler/load_snapshot.py
@@ -1,0 +1,138 @@
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+__all__ = ["LoadSnapshot"]
+
+import yaml
+import types
+import typing
+
+from lsst.ts import salobj
+from lsst.ts.idl.enums.Scheduler import SalIndex
+
+
+class LoadSnapshot(salobj.BaseScript):
+    """A base script that implements loading snapshots for the Scheduler.
+
+    Parameters
+    ----------
+    index : `int`
+        Index of Script SAL component.
+    scheduler_index : `int`
+        Index of the Scheduler to enable.
+    """
+
+    def __init__(self, index: int, scheduler_index: SalIndex) -> None:
+        super().__init__(
+            index=index,
+            descr=f"Load snapshot for {scheduler_index.name} Scheduler",
+        )
+
+        self.scheduler_remote = salobj.Remote(
+            domain=self.domain,
+            name="Scheduler",
+            index=scheduler_index,
+            include=[
+                "summaryState",
+                "heartbeat",
+                "largeFileObjectAvailable",
+            ],
+        )
+
+        self.timeout_start = 30.0
+
+        self.snapshot_uri: typing.Optional[str] = None
+
+    @classmethod
+    def get_schema(cls) -> typing.Optional[typing.Dict[str, typing.Any]]:
+        return yaml.safe_load(
+            """
+$schema: http://json-schema.org/draft-07/schema#
+$id: https://github.com/lsst-ts/ts_standardscripts/scheduler/base_load_snapshot.py
+title: BaseLoadSnapshot v2
+description: Configuration for loading scheduler snapshot.
+type: object
+properties:
+    snapshot:
+        description: >-
+            Snapshot to load. This must be either a valid uri or the
+            keyword "latest", which will cause it to load the last published
+            snapshot.
+        type: string
+required:
+    - snapshot
+additionalProperties: false
+        """
+        )
+
+    async def configure(self, config: types.SimpleNamespace) -> None:
+        """Configure the script.
+
+        Parameters
+        ----------
+        config : `types.SimpleNamespace`
+            Configuration.
+        """
+
+        self.log.info(f"Snapshot: {config.snapshot}.")
+
+        if config.snapshot == "latest":
+            self.log.debug("Loading latest snapshot.")
+            latest_snapshot = (
+                await self.scheduler_remote.evt_largeFileObjectAvailable.aget(
+                    timeout=self.timeout_start
+                )
+            )
+            if latest_snapshot is None:
+                raise RuntimeError(
+                    "No snapshot information from the Scheduler. "
+                    "In order to load a snapshot with the 'latest' option, the "
+                    "Scheduler must have published at least one snapshot."
+                )
+            else:
+                self.log.info(f"Latest snapshot uri: {latest_snapshot.url}")
+            self.snapshot_uri = latest_snapshot.url
+        else:
+            self.snapshot_uri = config.snapshot
+
+    def set_metadata(self, metadata: salobj.type_hints.BaseDdsDataType) -> None:
+        """Set metadata fields in the provided struct, given the
+        current configuration.
+
+        Parameters
+        ----------
+        metadata : ``self.evt_metadata.DataType()``
+            Metadata to update. Set those fields for which
+            you have useful information.
+
+        Notes
+        -----
+        This method is called after `configure` by `do_configure`.
+        The script state will be `ScriptState.UNCONFIGURED`.
+        """
+        metadata.duration = self.timeout_start
+
+    async def run(self) -> None:
+
+        await self.checkpoint("Loading snapshot")
+        await self.scheduler_remote.cmd_load.set_start(
+            uri=self.snapshot_uri, timeout=self.timeout_start
+        )
+        await self.checkpoint("Snapshot loaded")

--- a/python/lsst/ts/standardscripts/scheduler/resume.py
+++ b/python/lsst/ts/standardscripts/scheduler/resume.py
@@ -1,0 +1,89 @@
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+__all__ = ["Resume"]
+
+import types
+import typing
+
+from lsst.ts import salobj
+from lsst.ts.idl.enums.Scheduler import SalIndex
+
+
+class Resume(salobj.BaseScript):
+    """A base script that implements resuming the Scheduler.
+
+    Parameters
+    ----------
+    index : `int`
+        Index of Script SAL component.
+    scheduler_index : `int`
+        Index of the Scheduler to enable.
+    """
+
+    def __init__(self, index: int, scheduler_index: SalIndex) -> None:
+        super().__init__(
+            index=index,
+            descr=f"Resume {scheduler_index.name} Scheduler",
+        )
+
+        self.scheduler_remote = salobj.Remote(
+            domain=self.domain,
+            name="Scheduler",
+            index=scheduler_index,
+            include=[],
+        )
+
+        self.timeout_start = 30.0
+
+    @classmethod
+    def get_schema(cls) -> typing.Optional[typing.Dict[str, typing.Any]]:
+        return None
+
+    async def configure(self, config: types.SimpleNamespace) -> None:
+        """Configure the script.
+
+        Parameters
+        ----------
+        config : `types.SimpleNamespace`
+            Configuration.
+        """
+        pass
+
+    def set_metadata(self, metadata: salobj.type_hints.BaseDdsDataType) -> None:
+        """Set metadata fields in the provided struct, given the
+        current configuration.
+
+        Parameters
+        ----------
+        metadata : ``self.evt_metadata.DataType()``
+            Metadata to update. Set those fields for which
+            you have useful information.
+
+        Notes
+        -----
+        This method is called after `configure` by `do_configure`.
+        The script state will be `ScriptState.UNCONFIGURED`.
+        """
+        metadata.duration = self.timeout_start
+
+    async def run(self) -> None:
+
+        await self.scheduler_remote.cmd_resume.set_start(timeout=self.timeout_start)

--- a/python/lsst/ts/standardscripts/scheduler/set_desired_state.py
+++ b/python/lsst/ts/standardscripts/scheduler/set_desired_state.py
@@ -1,0 +1,223 @@
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+__all__ = ["SetDesiredState"]
+
+import types
+import typing
+import asyncio
+
+from lsst.ts import salobj
+from lsst.ts.idl.enums.Scheduler import SalIndex
+
+
+class SetDesiredState(salobj.BaseScript):
+    """A base script that implements setting the desired state for the
+    Scheduler.
+
+    Parameters
+    ----------
+    index : `int`
+        Index of Script SAL component.
+    descr : `str`
+        Script description.
+    scheduler_index : `int`
+        Index of the Scheduler to enable.
+    """
+
+    def __init__(
+        self,
+        index: int,
+        descr: str,
+        scheduler_index: SalIndex,
+        desired_state: salobj.State,
+    ) -> None:
+        super().__init__(index=index, descr=descr)
+
+        self.scheduler_remote = salobj.Remote(
+            domain=self.domain,
+            name="Scheduler",
+            index=scheduler_index,
+            include=["summaryState", "heartbeat"],
+        )
+
+        self.desired_state = desired_state
+
+        self.timeout_start = 30.0
+
+        self.configuration = ""
+
+        self._state_transition_methods_to_try = (
+            self._handle_csc_in_standby,
+            self._handle_csc_in_disabled_or_fault,
+            self._handle_csc_in_enabled,
+        )
+
+    @classmethod
+    def get_schema(cls) -> typing.Optional[typing.Dict[str, typing.Any]]:
+        return None
+
+    async def configure(self, config: types.SimpleNamespace) -> None:
+        pass
+
+    def set_metadata(self, metadata: salobj.type_hints.BaseDdsDataType) -> None:
+        """Set metadata fields in the provided struct, given the
+        current configuration.
+
+        Parameters
+        ----------
+        metadata : ``self.evt_metadata.DataType()``
+            Metadata to update. Set those fields for which
+            you have useful information.
+
+        Notes
+        -----
+        This method is called after `configure` by `do_configure`.
+        The script state will be `ScriptState.UNCONFIGURED`.
+        """
+        metadata.duration = self.timeout_start
+
+    async def assert_liveliness(self) -> None:
+        """Assert that the Scheduler is alive."""
+
+        try:
+            await self.scheduler_remote.evt_heartbeat.next(
+                flush=True,
+                timeout=salobj.base_script.HEARTBEAT_INTERVAL,
+            )
+        except asyncio.TimeoutError:
+            raise AssertionError(
+                f"No heartbeat from Scheduler in the last {salobj.base_script.HEARTBEAT_INTERVAL}s. "
+                "Make sure it is running before trying to enable."
+            )
+
+    def get_summary_state(self) -> typing.Optional[salobj.State]:
+        """Get Scheduler summary state."""
+        current_summary_state = self.scheduler_remote.evt_summaryState.get()
+
+        return (
+            None
+            if current_summary_state is None
+            else salobj.State(current_summary_state.summaryState)
+        )
+
+    async def handle_no_summary_state_data(self) -> None:
+        """Handle condition where no information about Scheduler summary state
+        is available.
+
+        Start by assuming Scheduler is in STANDBY, if this fails, assume it is
+        in DISABLED and finally in ENABLED.
+        """
+
+        for coro in self._state_transition_methods_to_try:
+            if await coro():
+                return
+
+        raise RuntimeError(f"Failed to transition CSC to {self.desired_state!r}.")
+
+    async def _handle_csc_in_standby(self) -> bool:
+        """Handle condition where CSC is in STANDBY."""
+
+        try:
+            await self.scheduler_remote.cmd_start.set_start(
+                configurationOverride=self.configuration,
+                timeout=self.timeout_start,
+            )
+        except salobj.AckError:
+            self.log.warning("Sending start command failed. CSC not in STANDBY")
+            return False
+        else:
+            await self.set_desired_state()
+            return True
+
+    async def _handle_csc_in_disabled_or_fault(self) -> bool:
+        """Handle condition where CSC is either in DISABLED or FAULT."""
+        try:
+            await self.scheduler_remote.cmd_standby.set_start(
+                timeout=self.timeout_start,
+            )
+        except salobj.AckError:
+            self.log.warning(
+                "Sending standby command failed. CSC not in DISABLED or FAULT."
+            )
+            return False
+        else:
+            await self.set_desired_state()
+            return True
+
+    async def _handle_csc_in_enabled(self) -> bool:
+        """Handler condition where CSC is in ENABLED."""
+        try:
+            await self.scheduler_remote.cmd_disable.set_start(
+                timeout=self.timeout_start,
+            )
+        except salobj.AckError:
+            self.log.warning("Sending disabled command failed. CSC not in ENABLED.")
+            return False
+        else:
+            await self.set_state_to_standby()
+            await self.set_desired_state()
+            return True
+
+    async def set_state_to_standby(self) -> None:
+        """Set Scheduler state to standby."""
+        await salobj.set_summary_state(
+            self.scheduler_remote,
+            salobj.State.STANDBY,
+        )
+
+    async def set_desired_state(self) -> None:
+        """Enable CSC."""
+        await salobj.set_summary_state(
+            self.scheduler_remote,
+            self.desired_state,
+            override=self.configuration,
+        )
+
+    async def run(self) -> None:
+        """Enable the Scheduler and exit."""
+
+        await self.checkpoint("Assert liveliness")
+        await self.assert_liveliness()
+
+        current_summary_state = self.get_summary_state()
+
+        if current_summary_state is None:
+            await self.checkpoint("Handling no summary state information")
+            await self.handle_no_summary_state_data()
+        elif (
+            current_summary_state in {salobj.State.ENABLED, salobj.State.DISABLED}
+            and self.desired_state != salobj.State.STANDBY
+        ):
+            await self.checkpoint(
+                f"Reset summary state to STANDBY before setting to {self.desired_state}"
+            )
+            self.log.warning(
+                f"Scheduler in {current_summary_state}, sending CSC to STANDBY then to {self.desired_state}."
+            )
+            await self.set_state_to_standby()
+            await self.set_desired_state()
+        else:
+            await self.checkpoint(
+                f"Setting desired state: {current_summary_state!r} -> {self.desired_state!r}"
+            )
+            await self.set_desired_state()
+
+        await self.checkpoint(f"Scheduler {self.desired_state}")

--- a/python/lsst/ts/standardscripts/scheduler/stop.py
+++ b/python/lsst/ts/standardscripts/scheduler/stop.py
@@ -1,0 +1,110 @@
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+__all__ = ["Stop"]
+
+import yaml
+import types
+import typing
+
+from lsst.ts import salobj
+from lsst.ts.idl.enums.Scheduler import SalIndex
+
+
+class Stop(salobj.BaseScript):
+    """A base script that implements resuming the Scheduler.
+
+    Parameters
+    ----------
+    index : `int`
+        Index of Script SAL component.
+    scheduler_index : `int`
+        Index of the Scheduler to enable.
+    """
+
+    def __init__(self, index: int, scheduler_index: SalIndex) -> None:
+        super().__init__(
+            index=index,
+            descr=f"Stop {scheduler_index.name} Scheduler",
+        )
+
+        self.scheduler_remote = salobj.Remote(
+            domain=self.domain,
+            name="Scheduler",
+            index=scheduler_index,
+            include=[],
+        )
+
+        self.timeout_start = 30.0
+        self.stop = False
+
+    @classmethod
+    def get_schema(cls) -> typing.Optional[typing.Dict[str, typing.Any]]:
+        return yaml.safe_load(
+            """
+$schema: http://json-schema.org/draft-07/schema#
+$id: https://github.com/lsst-ts/ts_standardscripts/scheduler/base_stop.py
+title: BaseStop v2
+description: Configuration for stopping scheduler.
+type: object
+properties:
+    stop:
+        description: >-
+            Should the Scheduler stop current observations in the queue?
+        type: boolean
+        default: false
+additionalProperties: false
+        """
+        )
+
+    async def configure(self, config: types.SimpleNamespace) -> None:
+        """Configure the script.
+
+        Parameters
+        ----------
+        config : `types.SimpleNamespace`
+            Configuration.
+        """
+        self.stop = config.stop
+
+    def set_metadata(self, metadata: salobj.type_hints.BaseDdsDataType) -> None:
+        """Set metadata fields in the provided struct, given the
+        current configuration.
+
+        Parameters
+        ----------
+        metadata : ``self.evt_metadata.DataType()``
+            Metadata to update. Set those fields for which
+            you have useful information.
+
+        Notes
+        -----
+        This method is called after `configure` by `do_configure`.
+        The script state will be `ScriptState.UNCONFIGURED`.
+        """
+        metadata.duration = self.timeout_start
+
+    async def run(self) -> None:
+
+        await self.checkpoint("Stopping scheduler")
+        await self.scheduler_remote.cmd_stop.set_start(
+            abort=self.stop, timeout=self.timeout_start
+        )
+        await self.checkpoint("Scheduler stopped")

--- a/python/lsst/ts/standardscripts/scheduler/testutils/__init__.py
+++ b/python/lsst/ts/standardscripts/scheduler/testutils/__init__.py
@@ -1,0 +1,22 @@
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+from .mock_scheduler import *
+from .base_scheduler_test_case import *

--- a/python/lsst/ts/standardscripts/scheduler/testutils/base_scheduler_test_case.py
+++ b/python/lsst/ts/standardscripts/scheduler/testutils/base_scheduler_test_case.py
@@ -1,0 +1,86 @@
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+__all__ = ["BaseSchedulerTestCase"]
+
+import random
+import typing
+import unittest
+import contextlib
+
+from lsst.ts import salobj
+from lsst.ts.idl.enums.Script import ScriptState
+
+from ...base_script_test_case import BaseScriptTestCase
+from .mock_scheduler import MockScheduler
+
+random.seed(47)  # for set_random_lsst_dds_partition_prefix
+
+
+class BaseSchedulerTestCase(BaseScriptTestCase, unittest.IsolatedAsyncioTestCase):
+    @contextlib.asynccontextmanager
+    async def make_controller(
+        self, initial_state: salobj.State, publish_initial_state: bool
+    ):
+        """Add a Test controller"""
+        async with MockScheduler(
+            index=1,
+            initial_state=initial_state,
+            publish_initial_state=publish_initial_state,
+        ) as controller:
+            self.controller = controller
+            yield
+
+    def assert_run(
+        self,
+        expected_commands: typing.Dict[str, int],
+        expected_overrides: typing.List[str],
+        expected_script_state: ScriptState,
+        expected_csc_state: salobj.State,
+    ) -> None:
+
+        for command in expected_commands:
+            with self.subTest(
+                f"successfull command execution {command}", command=command
+            ):
+                assert self.controller.n_commands[command] == expected_commands[command]
+
+        assert len(self.controller.overrides) == len(
+            expected_overrides
+        ), f"Expected overrides, {len(expected_overrides)} got {len(self.controller.overrides)}."
+
+        for expected_override, controller_override in zip(
+            expected_overrides, self.controller.overrides
+        ):
+            with self.subTest(
+                "expected overrides",
+                expected_override=expected_override,
+                controller_override=controller_override,
+            ):
+                assert expected_override == controller_override
+
+        assert self.script.state.state == expected_script_state
+        assert self.controller.evt_summaryState.data.summaryState == expected_csc_state
+
+    def assert_loaded_snapshots(self, snapshots: typing.List[str]) -> None:
+
+        assert len(self.controller.snapshots) == len(snapshots)
+        for snapshot in snapshots:
+            assert snapshot in self.controller.snapshots

--- a/python/lsst/ts/standardscripts/scheduler/testutils/mock_scheduler.py
+++ b/python/lsst/ts/standardscripts/scheduler/testutils/mock_scheduler.py
@@ -1,0 +1,140 @@
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+__all__ = ["MockScheduler"]
+
+import asyncio
+
+from lsst.ts import salobj
+
+
+class MockScheduler(salobj.Controller):
+    """A simple Scheduler CSC simulator."""
+
+    def __init__(
+        self, index, initial_state=salobj.State.STANDBY, publish_initial_state=True
+    ):
+        super().__init__(name="Scheduler", index=index, do_callbacks=False)
+
+        self.n_commands = dict(
+            disable=0,
+            enable=0,
+            exitControl=0,
+            standby=0,
+            start=0,
+        )
+
+        self.running = False
+
+        self.overrides = []
+        self.snapshots = []
+        self.abort_observations = []
+
+        self.publish_initial_state = publish_initial_state
+
+        self.valid_configuration_overrides = ["valid_test_config.yaml", ""]
+        self.valid_snapshot = (
+            "https://s3.cp.lsst.org/rubinobs-lfa-cp/Scheduler:2/"
+            "Scheduler:2/2022/04/07/Scheduler:2_Scheduler:2_2022-04-08T09:56:57.726.p"
+        )
+
+        self.cmd_disable.callback = self.do_disable
+        self.cmd_enable.callback = self.do_enable
+        self.cmd_standby.callback = self.do_standby
+        self.cmd_start.callback = self.do_start
+        self.cmd_load.callback = self.do_load
+        self.cmd_resume.callback = self.do_resume
+        self.cmd_stop.callback = self.do_stop
+        self.evt_summaryState.set(summaryState=initial_state)
+
+    async def start(self):
+        if self.publish_initial_state:
+            await self.evt_summaryState.write()
+            await self.evt_largeFileObjectAvailable.set_write(url=self.valid_snapshot)
+
+        await super().start()
+
+        self._heartbeat_task = asyncio.create_task(self.publish_heartbeat())
+
+    async def publish_heartbeat(self):
+        while self.isopen:
+            await self.evt_heartbeat.write()
+            await asyncio.sleep(1.0)
+
+    async def do_disable(self, data):
+        await self._do_change_state(
+            cmd_name="disable",
+            allowed_current_states={salobj.State.ENABLED},
+            new_state=salobj.State.DISABLED,
+        )
+
+    async def do_enable(self, data):
+        await self._do_change_state(
+            cmd_name="enable",
+            allowed_current_states={salobj.State.DISABLED},
+            new_state=salobj.State.ENABLED,
+        )
+
+    async def do_standby(self, data):
+        await self._do_change_state(
+            cmd_name="standby",
+            allowed_current_states={salobj.State.DISABLED, salobj.State.FAULT},
+            new_state=salobj.State.STANDBY,
+        )
+
+    async def do_start(self, data):
+
+        if data.configurationOverride not in self.valid_configuration_overrides:
+            raise salobj.base.ExpectedError(
+                f"Config file {data.configurationOverride} does not exist."
+            )
+        await self._do_change_state(
+            cmd_name="start",
+            allowed_current_states={salobj.State.STANDBY},
+            new_state=salobj.State.DISABLED,
+        )
+
+        self.overrides.append(data.configurationOverride)
+
+    async def do_load(self, data):
+        assert self.evt_summaryState.data.summaryState == salobj.State.ENABLED
+        assert not self.running
+        assert data.uri == self.valid_snapshot
+
+        self.snapshots.append(data.uri)
+
+    async def do_resume(self, data):
+        assert self.evt_summaryState.data.summaryState == salobj.State.ENABLED
+        self.running = True
+
+    async def do_stop(self, data):
+        assert self.evt_summaryState.data.summaryState == salobj.State.ENABLED
+        self.abort_observations.append(data.abort)
+        self.running = False
+
+    async def _do_change_state(self, cmd_name, allowed_current_states, new_state):
+
+        current_state = self.evt_summaryState.data.summaryState
+        if current_state not in allowed_current_states:
+            raise salobj.base.ExpectedError(
+                f"{cmd_name} not allowed in state {current_state!r}"
+            )
+        self.n_commands[cmd_name] += 1
+        await self.evt_summaryState.set_write(summaryState=new_state)

--- a/scripts/auxtel/scheduler/enable.py
+++ b/scripts/auxtel/scheduler/enable.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+import asyncio
+
+from lsst.ts.idl.enums.Scheduler import SalIndex
+from lsst.ts.standardscripts.scheduler.enable import Enable
+
+
+class ATSchedulerEnable(Enable):
+    """Enable the ATScheduler."""
+
+    def __init__(self, index: int) -> None:
+        super().__init__(
+            index,
+            scheduler_index=SalIndex.AUX_TEL,
+        )
+
+
+asyncio.run(ATSchedulerEnable.amain())

--- a/scripts/auxtel/scheduler/load_snapshot.py
+++ b/scripts/auxtel/scheduler/load_snapshot.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+import asyncio
+
+from lsst.ts.idl.enums.Scheduler import SalIndex
+from lsst.ts.standardscripts.scheduler.load_snapshot import LoadSnapshot
+
+
+class ATSchedulerLoadSnapshot(LoadSnapshot):
+    """Load snapshot for ATScheduler."""
+
+    def __init__(self, index: int) -> None:
+        super().__init__(
+            index,
+            scheduler_index=SalIndex.AUX_TEL,
+        )
+
+
+asyncio.run(ATSchedulerLoadSnapshot.amain())

--- a/scripts/auxtel/scheduler/resume.py
+++ b/scripts/auxtel/scheduler/resume.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+import asyncio
+
+from lsst.ts.idl.enums.Scheduler import SalIndex
+from lsst.ts.standardscripts.scheduler.resume import Resume
+
+
+class ATSchedulerResume(Resume):
+    """Resume ATScheduler."""
+
+    def __init__(self, index: int) -> None:
+        super().__init__(
+            index,
+            scheduler_index=SalIndex.AUX_TEL,
+        )
+
+
+asyncio.run(ATSchedulerResume.amain())

--- a/scripts/auxtel/scheduler/standby.py
+++ b/scripts/auxtel/scheduler/standby.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+import asyncio
+
+from lsst.ts import salobj
+from lsst.ts.idl.enums.Scheduler import SalIndex
+from lsst.ts.standardscripts.scheduler import SetDesiredState
+
+
+class ATSchedulerStandby(SetDesiredState):
+    """Send ATScheduler to STANDBY state."""
+
+    def __init__(self, index: int) -> None:
+        super().__init__(
+            index,
+            desired_state=salobj.State.STANDBY,
+            descr="Send AuxTel Scheduler to standby state",
+            scheduler_index=SalIndex.AUX_TEL,
+        )
+
+
+asyncio.run(ATSchedulerStandby.amain())

--- a/scripts/auxtel/scheduler/stop.py
+++ b/scripts/auxtel/scheduler/stop.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+import asyncio
+
+from lsst.ts.idl.enums.Scheduler import SalIndex
+from lsst.ts.standardscripts.scheduler.stop import Stop
+
+
+class ATSchedulerStop(Stop):
+    """Stop ATScheduler."""
+
+    def __init__(self, index: int) -> None:
+        super().__init__(
+            index,
+            scheduler_index=SalIndex.AUX_TEL,
+        )
+
+
+asyncio.run(ATSchedulerStop.amain())

--- a/scripts/maintel/scheduler/enable.py
+++ b/scripts/maintel/scheduler/enable.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+import asyncio
+
+from lsst.ts.idl.enums.Scheduler import SalIndex
+from lsst.ts.standardscripts.scheduler.enable import Enable
+
+
+class MTSchedulerEnable(Enable):
+    """Enable the MTScheduler."""
+
+    def __init__(self, index: int) -> None:
+        super().__init__(
+            index,
+            scheduler_index=SalIndex.MAIN_TEL,
+        )
+
+
+asyncio.run(MTSchedulerEnable.amain())

--- a/scripts/maintel/scheduler/load_snapshot.py
+++ b/scripts/maintel/scheduler/load_snapshot.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+import asyncio
+
+from lsst.ts.idl.enums.Scheduler import SalIndex
+from lsst.ts.standardscripts.scheduler.load_snapshot import LoadSnapshot
+
+
+class MTSchedulerLoadSnapshot(LoadSnapshot):
+    """Load snapshot for MTScheduler."""
+
+    def __init__(self, index: int) -> None:
+        super().__init__(
+            index,
+            scheduler_index=SalIndex.MAIN_TEL,
+        )
+
+
+asyncio.run(MTSchedulerLoadSnapshot.amain())

--- a/scripts/maintel/scheduler/resume.py
+++ b/scripts/maintel/scheduler/resume.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+import asyncio
+
+from lsst.ts.idl.enums.Scheduler import SalIndex
+from lsst.ts.standardscripts.scheduler.resume import Resume
+
+
+class MTSchedulerResume(Resume):
+    """Resume MTScheduler."""
+
+    def __init__(self, index: int) -> None:
+        super().__init__(
+            index,
+            scheduler_index=SalIndex.MAIN_TEL,
+        )
+
+
+asyncio.run(MTSchedulerResume.amain())

--- a/scripts/maintel/scheduler/standby.py
+++ b/scripts/maintel/scheduler/standby.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+import asyncio
+
+from lsst.ts import salobj
+from lsst.ts.idl.enums.Scheduler import SalIndex
+from lsst.ts.standardscripts.scheduler import SetDesiredState
+
+
+class MTSchedulerStandby(SetDesiredState):
+    """Send MTScheduler to STANDBY state."""
+
+    def __init__(self, index: int) -> None:
+        super().__init__(
+            index,
+            desired_state=salobj.State.STANDBY,
+            descr="Send MainTel Scheduler to standby state",
+            scheduler_index=SalIndex.MAIN_TEL,
+        )
+
+
+asyncio.run(MTSchedulerStandby.amain())

--- a/scripts/maintel/scheduler/stop.py
+++ b/scripts/maintel/scheduler/stop.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+import asyncio
+
+from lsst.ts.idl.enums.Scheduler import SalIndex
+from lsst.ts.standardscripts.scheduler.stop import Stop
+
+
+class MTSchedulerStop(Stop):
+    """Stop MTScheduler."""
+
+    def __init__(self, index: int) -> None:
+        super().__init__(
+            index,
+            scheduler_index=SalIndex.MAIN_TEL,
+        )
+
+
+asyncio.run(MTSchedulerStop.amain())

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ exclude =
 
 [tool:pytest]
 addopts = --black --flake8 --ignore-glob=*/version.py
+asyncio_mode=auto
 flake8-ignore = E133 E203 E226 E228 N802 N803 N806 N812 N813 N815 N816 W503
 
 [metadata]

--- a/tests/test_auxtel_track_target_and_take_image.py
+++ b/tests/test_auxtel_track_target_and_take_image.py
@@ -210,13 +210,24 @@ class TestAuxTelTrackTargetAndTakeImage(
             with pytest.raises(AssertionError):
                 await self.run_script()
 
-            self.script.atcs.slew_icrs.assert_awaited_once_with(
-                ra=configuration_full["ra"],
-                dec=configuration_full["dec"],
-                rot=configuration_full["rot_sky"],
-                rot_type=RotType.Sky,
-                target_name=configuration_full["name"],
-            )
+            slew_icrs_expected_calls = [
+                unittest.mock.call(
+                    ra=configuration_full["ra"],
+                    dec=configuration_full["dec"],
+                    rot=configuration_full["rot_sky"],
+                    rot_type=RotType.Sky,
+                    target_name=configuration_full["name"],
+                ),
+                unittest.mock.call(
+                    ra=configuration_full["ra"],
+                    dec=configuration_full["dec"],
+                    rot=180.0 + configuration_full["rot_sky"],
+                    rot_type=RotType.Sky,
+                    target_name=configuration_full["name"],
+                ),
+            ]
+
+            self.script.atcs.slew_icrs.assert_has_awaits(slew_icrs_expected_calls)
             self.script.latiss.setup_atspec.assert_awaited_once_with(
                 grating=configuration_full["grating"],
                 filter=configuration_full["band_filter"],

--- a/tests/test_scheduler_enable.py
+++ b/tests/test_scheduler_enable.py
@@ -1,0 +1,296 @@
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+import logging
+import unittest
+
+import pytest
+
+from lsst.ts import salobj
+from lsst.ts.idl.enums.Script import ScriptState
+from lsst.ts.idl.enums.Scheduler import SalIndex
+from lsst.ts.standardscripts import get_scripts_dir
+from lsst.ts.standardscripts.scheduler.enable import Enable
+from lsst.ts.standardscripts.scheduler.testutils import BaseSchedulerTestCase
+
+
+class TestSchedulerBaseEnable(BaseSchedulerTestCase):
+    async def basic_make_script(self, index):
+        self.script = Enable(
+            index=index,
+            scheduler_index=SalIndex.MAIN_TEL,
+        )
+        return [self.script]
+
+    async def test_configure_errors(self):
+        """Test error handling in the do_configure method."""
+        async with self.make_script():
+            config_data = self.script.cmd_configure.DataType()
+            for bad_config in (
+                "",  # need at least one configuration
+                "confog: valid_test_config.yaml",  # typo in "config" should fail
+            ):
+                with self.subTest(bad_config=bad_config):
+                    config_data.config = bad_config
+                    with pytest.raises(salobj.ExpectedError):
+                        await self.script.do_configure(config_data)
+
+    async def test_configure_good(self):
+        """Test the configure method with a valid configuration.
+
+        Also exercise verbose=True for make_script.
+        """
+        async with self.make_script(verbose=True):
+
+            with self.assertLogs(self.script.log, level=logging.DEBUG) as script_logs:
+                await self.configure_script(config="valid_test_config.yaml")
+
+            assert (
+                "INFO:Script:Scheduler configuration: valid_test_config.yaml"
+                in script_logs.output
+            )
+
+    async def test_run_fail_invalid_config(self):
+        """Set one remote to two states, including overrides."""
+        async with self.make_script(), self.make_controller(
+            initial_state=salobj.State.STANDBY, publish_initial_state=True
+        ):
+
+            await self.configure_script(config="invalid_test_config.yaml")
+
+            with self.assertRaises(AssertionError):
+                await self.run_script()
+
+            self.assert_run(
+                expected_commands=dict(
+                    standby=0,
+                    start=0,
+                    enable=0,
+                    disable=0,
+                ),
+                expected_overrides=[],
+                expected_script_state=ScriptState.FAILED,
+                expected_csc_state=salobj.State.STANDBY,
+            )
+
+    async def test_run_fail_invalid_config_no_historical_data(self):
+        """Set one remote to two states, including overrides."""
+        async with self.make_script(), self.make_controller(
+            initial_state=salobj.State.STANDBY, publish_initial_state=True
+        ):
+
+            await self.configure_script(config="invalid_test_config.yaml")
+
+            with self.assertRaises(AssertionError):
+                await self.run_script()
+
+            self.assert_run(
+                expected_commands=dict(
+                    standby=0,
+                    start=0,
+                    enable=0,
+                    disable=0,
+                ),
+                expected_overrides=[],
+                expected_script_state=ScriptState.FAILED,
+                expected_csc_state=salobj.State.STANDBY,
+            )
+
+    async def test_run_csc_in_standby(self):
+        """Set one remote to two states, including overrides."""
+        async with self.make_script(), self.make_controller(
+            initial_state=salobj.State.STANDBY, publish_initial_state=True
+        ):
+
+            await self.configure_script(config="valid_test_config.yaml")
+            await self.run_script()
+
+            self.assert_run(
+                expected_commands=dict(
+                    standby=0,
+                    start=1,
+                    enable=1,
+                    disable=0,
+                ),
+                expected_overrides=["valid_test_config.yaml"],
+                expected_script_state=ScriptState.DONE,
+                expected_csc_state=salobj.State.ENABLED,
+            )
+
+    async def test_run_csc_in_standby_no_historical_data(self):
+        """Set one remote to two states, including overrides."""
+        async with self.make_script(), self.make_controller(
+            initial_state=salobj.State.STANDBY, publish_initial_state=False
+        ):
+
+            await self.configure_script(config="valid_test_config.yaml")
+            await self.run_script()
+
+            self.assert_run(
+                expected_commands=dict(
+                    standby=0,
+                    start=1,
+                    enable=1,
+                    disable=0,
+                ),
+                expected_overrides=["valid_test_config.yaml"],
+                expected_script_state=ScriptState.DONE,
+                expected_csc_state=salobj.State.ENABLED,
+            )
+
+    async def test_run_csc_in_disabled(self):
+        """Set one remote to two states, including overrides."""
+        async with self.make_script(), self.make_controller(
+            initial_state=salobj.State.DISABLED, publish_initial_state=True
+        ):
+
+            await self.configure_script(config="valid_test_config.yaml")
+            await self.run_script()
+
+            self.assert_run(
+                expected_commands=dict(
+                    standby=1,
+                    start=1,
+                    enable=1,
+                    disable=0,
+                ),
+                expected_overrides=["valid_test_config.yaml"],
+                expected_script_state=ScriptState.DONE,
+                expected_csc_state=salobj.State.ENABLED,
+            )
+
+    async def test_run_csc_in_disabled_no_historical_data(self):
+        """Set one remote to two states, including overrides."""
+        async with self.make_script(), self.make_controller(
+            initial_state=salobj.State.DISABLED, publish_initial_state=False
+        ):
+
+            await self.configure_script(config="valid_test_config.yaml")
+            await self.run_script()
+
+            self.assert_run(
+                expected_commands=dict(
+                    standby=1,
+                    start=1,
+                    enable=1,
+                    disable=0,
+                ),
+                expected_overrides=["valid_test_config.yaml"],
+                expected_script_state=ScriptState.DONE,
+                expected_csc_state=salobj.State.ENABLED,
+            )
+
+    async def test_run_csc_in_enabled(self):
+        """Set one remote to two states, including overrides."""
+        async with self.make_script(), self.make_controller(
+            initial_state=salobj.State.ENABLED, publish_initial_state=True
+        ):
+
+            await self.configure_script(config="valid_test_config.yaml")
+            await self.run_script()
+
+            self.assert_run(
+                expected_commands=dict(
+                    standby=1,
+                    start=1,
+                    enable=1,
+                    disable=1,
+                ),
+                expected_overrides=["valid_test_config.yaml"],
+                expected_script_state=ScriptState.DONE,
+                expected_csc_state=salobj.State.ENABLED,
+            )
+
+    async def test_run_csc_in_enabled_no_historical_data(self):
+        """Set one remote to two states, including overrides."""
+        async with self.make_script(), self.make_controller(
+            initial_state=salobj.State.ENABLED, publish_initial_state=True
+        ):
+
+            await self.configure_script(config="valid_test_config.yaml")
+            await self.run_script()
+
+            self.assert_run(
+                expected_commands=dict(
+                    standby=1,
+                    start=1,
+                    enable=1,
+                    disable=1,
+                ),
+                expected_overrides=["valid_test_config.yaml"],
+                expected_script_state=ScriptState.DONE,
+                expected_csc_state=salobj.State.ENABLED,
+            )
+
+    async def test_run_csc_in_fault(self):
+        """Set one remote to two states, including overrides."""
+        async with self.make_script(), self.make_controller(
+            initial_state=salobj.State.FAULT, publish_initial_state=True
+        ):
+
+            await self.configure_script(config="valid_test_config.yaml")
+            await self.run_script()
+
+            self.assert_run(
+                expected_commands=dict(
+                    standby=1,
+                    start=1,
+                    enable=1,
+                    disable=0,
+                ),
+                expected_overrides=["valid_test_config.yaml"],
+                expected_script_state=ScriptState.DONE,
+                expected_csc_state=salobj.State.ENABLED,
+            )
+
+    async def test_run_csc_in_fault_no_historical_data(self):
+        """Set one remote to two states, including overrides."""
+        async with self.make_script(), self.make_controller(
+            initial_state=salobj.State.FAULT, publish_initial_state=False
+        ):
+
+            await self.configure_script(config="valid_test_config.yaml")
+            await self.run_script()
+
+            self.assert_run(
+                expected_commands=dict(
+                    standby=1,
+                    start=1,
+                    enable=1,
+                    disable=0,
+                ),
+                expected_overrides=["valid_test_config.yaml"],
+                expected_script_state=ScriptState.DONE,
+                expected_csc_state=salobj.State.ENABLED,
+            )
+
+    async def test_auxtel_executable(self):
+        scripts_dir = get_scripts_dir()
+        script_path = scripts_dir / "auxtel" / "scheduler" / "enable.py"
+        await self.check_executable(script_path)
+
+    async def test_maintel_executable(self):
+        scripts_dir = get_scripts_dir()
+        script_path = scripts_dir / "maintel" / "scheduler" / "enable.py"
+        await self.check_executable(script_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scheduler_load_snapshot.py
+++ b/tests/test_scheduler_load_snapshot.py
@@ -1,0 +1,91 @@
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+import pytest
+
+from lsst.ts import salobj
+from lsst.ts.idl.enums.Scheduler import SalIndex
+
+from lsst.ts.standardscripts import get_scripts_dir
+from lsst.ts.standardscripts.scheduler.load_snapshot import LoadSnapshot
+from lsst.ts.standardscripts.scheduler.testutils import BaseSchedulerTestCase
+
+
+class TestSchedulerBaseLoadSnapshot(BaseSchedulerTestCase):
+    async def basic_make_script(self, index):
+        self.script = LoadSnapshot(
+            index=index,
+            scheduler_index=SalIndex.MAIN_TEL,
+        )
+        return [self.script]
+
+    async def test_valid_uri(self) -> None:
+
+        async with self.make_script(), self.make_controller(
+            initial_state=salobj.State.ENABLED, publish_initial_state=True
+        ):
+
+            await self.configure_script(snapshot=self.controller.valid_snapshot)
+            await self.run_script()
+
+            self.assert_loaded_snapshots(snapshots=[self.controller.valid_snapshot])
+
+    async def test_latest(self) -> None:
+
+        async with self.make_script(), self.make_controller(
+            initial_state=salobj.State.ENABLED, publish_initial_state=True
+        ):
+
+            await self.configure_script(snapshot="latest")
+            await self.run_script()
+
+            self.assert_loaded_snapshots(snapshots=[self.controller.valid_snapshot])
+
+    async def test_invalid_uri(self) -> None:
+
+        async with self.make_script(), self.make_controller(
+            initial_state=salobj.State.ENABLED, publish_initial_state=True
+        ):
+
+            await self.configure_script(snapshot="invalid")
+
+            with self.assertRaises(AssertionError):
+                await self.run_script()
+
+            self.assert_loaded_snapshots(snapshots=[])
+
+    async def test_fail_config_latest_not_published(self) -> None:
+
+        async with self.make_script(), self.make_controller(
+            initial_state=salobj.State.ENABLED, publish_initial_state=False
+        ):
+
+            with pytest.raises(salobj.ExpectedError):
+                await self.configure_script(snapshot="latest")
+
+    async def test_auxtel_executable(self):
+        scripts_dir = get_scripts_dir()
+        script_path = scripts_dir / "auxtel" / "scheduler" / "load_snapshot.py"
+        await self.check_executable(script_path)
+
+    async def test_maintel_executable(self):
+        scripts_dir = get_scripts_dir()
+        script_path = scripts_dir / "maintel" / "scheduler" / "load_snapshot.py"
+        await self.check_executable(script_path)

--- a/tests/test_scheduler_resume.py
+++ b/tests/test_scheduler_resume.py
@@ -1,0 +1,56 @@
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+from lsst.ts import salobj
+from lsst.ts.idl.enums.Scheduler import SalIndex
+
+from lsst.ts.standardscripts import get_scripts_dir
+from lsst.ts.standardscripts.scheduler.resume import Resume
+from lsst.ts.standardscripts.scheduler.testutils import BaseSchedulerTestCase
+
+
+class TestSchedulerBaseResume(BaseSchedulerTestCase):
+    async def basic_make_script(self, index):
+        self.script = Resume(
+            index=index,
+            scheduler_index=SalIndex.MAIN_TEL,
+        )
+        return [self.script]
+
+    async def test_run(self) -> None:
+
+        async with self.make_script(), self.make_controller(
+            initial_state=salobj.State.ENABLED, publish_initial_state=True
+        ):
+
+            await self.configure_script()
+            await self.run_script()
+
+            assert self.controller.running
+
+    async def test_auxtel_executable(self):
+        scripts_dir = get_scripts_dir()
+        script_path = scripts_dir / "auxtel" / "scheduler" / "resume.py"
+        await self.check_executable(script_path)
+
+    async def test_maintel_executable(self):
+        scripts_dir = get_scripts_dir()
+        script_path = scripts_dir / "maintel" / "scheduler" / "resume.py"
+        await self.check_executable(script_path)

--- a/tests/test_scheduler_standby.py
+++ b/tests/test_scheduler_standby.py
@@ -1,0 +1,222 @@
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+import unittest
+
+from lsst.ts import salobj
+from lsst.ts.idl.enums.Script import ScriptState
+from lsst.ts.idl.enums.Scheduler import SalIndex
+
+from lsst.ts.standardscripts import get_scripts_dir
+from lsst.ts.standardscripts.scheduler import SetDesiredState
+from lsst.ts.standardscripts.scheduler.testutils import BaseSchedulerTestCase
+
+
+class TestSchedulerBaseStandBy(BaseSchedulerTestCase):
+    async def basic_make_script(self, index):
+        self.script = SetDesiredState(
+            index=index,
+            desired_state=salobj.State.STANDBY,
+            descr="Send Scheduler to standby state",
+            scheduler_index=SalIndex.MAIN_TEL,
+        )
+        return [self.script]
+
+    async def test_run_csc_in_standby(self):
+        """Set one remote to two states, including overrides."""
+        async with self.make_script(), self.make_controller(
+            initial_state=salobj.State.STANDBY, publish_initial_state=True
+        ):
+
+            await self.configure_script()
+            await self.run_script()
+
+            self.assert_run(
+                expected_commands=dict(
+                    standby=0,
+                    start=0,
+                    enable=0,
+                    disable=0,
+                ),
+                expected_overrides=[],
+                expected_script_state=ScriptState.DONE,
+                expected_csc_state=salobj.State.STANDBY,
+            )
+
+    async def test_run_csc_in_standby_no_historical_data(self):
+        """Set one remote to two states, including overrides."""
+        async with self.make_script(), self.make_controller(
+            initial_state=salobj.State.STANDBY, publish_initial_state=False
+        ):
+
+            await self.configure_script()
+            await self.run_script()
+
+            self.assert_run(
+                expected_commands=dict(
+                    standby=1,
+                    start=1,
+                    enable=0,
+                    disable=0,
+                ),
+                expected_overrides=[""],
+                expected_script_state=ScriptState.DONE,
+                expected_csc_state=salobj.State.STANDBY,
+            )
+
+    async def test_run_csc_in_disabled(self):
+        """Set one remote to two states, including overrides."""
+        async with self.make_script(), self.make_controller(
+            initial_state=salobj.State.DISABLED, publish_initial_state=True
+        ):
+
+            await self.configure_script()
+            await self.run_script()
+
+            self.assert_run(
+                expected_commands=dict(
+                    standby=1,
+                    start=0,
+                    enable=0,
+                    disable=0,
+                ),
+                expected_overrides=[],
+                expected_script_state=ScriptState.DONE,
+                expected_csc_state=salobj.State.STANDBY,
+            )
+
+    async def test_run_csc_in_disabled_no_historical_data(self):
+        """Set one remote to two states, including overrides."""
+        async with self.make_script(), self.make_controller(
+            initial_state=salobj.State.DISABLED, publish_initial_state=False
+        ):
+
+            await self.configure_script()
+            await self.run_script()
+
+            self.assert_run(
+                expected_commands=dict(
+                    standby=1,
+                    start=0,
+                    enable=0,
+                    disable=0,
+                ),
+                expected_overrides=[],
+                expected_script_state=ScriptState.DONE,
+                expected_csc_state=salobj.State.STANDBY,
+            )
+
+    async def test_run_csc_in_enabled(self):
+        """Set one remote to two states, including overrides."""
+        async with self.make_script(), self.make_controller(
+            initial_state=salobj.State.ENABLED, publish_initial_state=True
+        ):
+
+            await self.configure_script()
+            await self.run_script()
+
+            self.assert_run(
+                expected_commands=dict(
+                    standby=1,
+                    start=0,
+                    enable=0,
+                    disable=1,
+                ),
+                expected_overrides=[],
+                expected_script_state=ScriptState.DONE,
+                expected_csc_state=salobj.State.STANDBY,
+            )
+
+    async def test_run_csc_in_enabled_no_historical_data(self):
+        """Set one remote to two states, including overrides."""
+        async with self.make_script(), self.make_controller(
+            initial_state=salobj.State.ENABLED, publish_initial_state=True
+        ):
+
+            await self.configure_script()
+            await self.run_script()
+
+            self.assert_run(
+                expected_commands=dict(
+                    standby=1,
+                    start=0,
+                    enable=0,
+                    disable=1,
+                ),
+                expected_overrides=[],
+                expected_script_state=ScriptState.DONE,
+                expected_csc_state=salobj.State.STANDBY,
+            )
+
+    async def test_run_csc_in_fault(self):
+        """Set one remote to two states, including overrides."""
+        async with self.make_script(), self.make_controller(
+            initial_state=salobj.State.FAULT, publish_initial_state=True
+        ):
+
+            await self.configure_script()
+            await self.run_script()
+
+            self.assert_run(
+                expected_commands=dict(
+                    standby=1,
+                    start=0,
+                    enable=0,
+                    disable=0,
+                ),
+                expected_overrides=[],
+                expected_script_state=ScriptState.DONE,
+                expected_csc_state=salobj.State.STANDBY,
+            )
+
+    async def test_run_csc_in_fault_no_historical_data(self):
+        """Set one remote to two states, including overrides."""
+        async with self.make_script(), self.make_controller(
+            initial_state=salobj.State.FAULT, publish_initial_state=False
+        ):
+
+            await self.configure_script()
+            await self.run_script()
+
+            self.assert_run(
+                expected_commands=dict(
+                    standby=1,
+                    start=0,
+                    enable=0,
+                    disable=0,
+                ),
+                expected_overrides=[],
+                expected_script_state=ScriptState.DONE,
+                expected_csc_state=salobj.State.STANDBY,
+            )
+
+    async def test_auxtel_executable(self):
+        scripts_dir = get_scripts_dir()
+        script_path = scripts_dir / "auxtel" / "scheduler" / "standby.py"
+        await self.check_executable(script_path)
+
+    async def test_maintel_executable(self):
+        scripts_dir = get_scripts_dir()
+        script_path = scripts_dir / "maintel" / "scheduler" / "standby.py"
+        await self.check_executable(script_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scheduler_stop.py
+++ b/tests/test_scheduler_stop.py
@@ -1,0 +1,81 @@
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+from lsst.ts import salobj
+from lsst.ts.idl.enums.Scheduler import SalIndex
+
+from lsst.ts.standardscripts import get_scripts_dir
+from lsst.ts.standardscripts.scheduler.stop import Stop
+from lsst.ts.standardscripts.scheduler.testutils import BaseSchedulerTestCase
+
+
+class TestSchedulerBaseStop(BaseSchedulerTestCase):
+    async def basic_make_script(self, index):
+        self.script = Stop(
+            index=index,
+            scheduler_index=SalIndex.MAIN_TEL,
+        )
+        return [self.script]
+
+    async def test_no_stop_default(self) -> None:
+
+        async with self.make_script(), self.make_controller(
+            initial_state=salobj.State.ENABLED, publish_initial_state=True
+        ):
+
+            await self.configure_script()
+            await self.run_script()
+
+            assert len(self.controller.abort_observations) == 1
+            assert not self.controller.abort_observations[0]
+
+    async def test_no_stop_explicit(self) -> None:
+
+        async with self.make_script(), self.make_controller(
+            initial_state=salobj.State.ENABLED, publish_initial_state=True
+        ):
+
+            await self.configure_script(stop=False)
+            await self.run_script()
+
+            assert len(self.controller.abort_observations) == 1
+            assert not self.controller.abort_observations[0]
+
+    async def test_stop(self) -> None:
+
+        async with self.make_script(), self.make_controller(
+            initial_state=salobj.State.ENABLED, publish_initial_state=True
+        ):
+
+            await self.configure_script(stop=True)
+            await self.run_script()
+
+            assert len(self.controller.abort_observations) == 1
+            assert self.controller.abort_observations[0]
+
+    async def test_auxtel_executable(self):
+        scripts_dir = get_scripts_dir()
+        script_path = scripts_dir / "auxtel" / "scheduler" / "stop.py"
+        await self.check_executable(script_path)
+
+    async def test_maintel_executable(self):
+        scripts_dir = get_scripts_dir()
+        script_path = scripts_dir / "maintel" / "scheduler" / "stop.py"
+        await self.check_executable(script_path)


### PR DESCRIPTION
Add some scripts to help Scheduler operations. I have derived this set of scripts from our experiencing operating the Scheduler in the last couple runs with the Auxiliary Telescope. The main goal was to make it easier for night crew to interact with the scheduler minimizing the amount of typing required to perform basic tasks and also creating some protections against the most common issues we normally encounter. You will see, for instance, there is a handler for the situation where historical data is lost. This is very particular to some issues we face with DDS from time to time, but it is something that creates a lot of confusion when it happens. So I thought I might add this protection. I know it is probably not the best solution to the problem and I hope we will be able to remove this in the future. Just thought I'd give a foreword about the problem so you have and idea about why it is there.