### PR TITLE
Tickets/dm 35737 - Update maintel/SetupMTCS to fix bug when starting m1m3

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,14 @@
 Version History
 ===============
 
+v1.14.3
+-------
+
+* In ``maintel/SetupMTCS``
+
+  * fix bug that caused ``mtcs.raise_m1m3`` to start but not to complete.
+  * fix ``mtcs.enable_compensation_mode`` argument.
+
 v1.14.2
 -------
 

--- a/python/lsst/ts/standardscripts/maintel/setup_mtcs.py
+++ b/python/lsst/ts/standardscripts/maintel/setup_mtcs.py
@@ -20,9 +20,7 @@
 
 __all__ = ["SetupMTCS"]
 
-import asyncio
 import yaml
-
 import pandas as pd
 
 from lsst.ts import salobj
@@ -341,7 +339,7 @@ class SetupMTCS(salobj.BaseScript):
         )
 
         self.log.info("Raising M1M3")
-        asyncio.create_task(self.mtcs.raise_m1m3())
+        await self.mtcs.raise_m1m3()
 
         self.log.info("M1M3 - Enable and reset balance forces")
         await self.mtcs.enable_m1m3_balance_system()
@@ -376,7 +374,7 @@ class SetupMTCS(salobj.BaseScript):
             overrides={component: self.config.overrides[component]},
         )
 
-        await self.mtcs.enable_compensation_mode(components=component)
+        await self.mtcs.enable_compensation_mode(component=component)
 
         if index == 1:
             await self.mtcs.reset_camera_hexapod_position()


### PR DESCRIPTION
This is the command being used to raise the M1M3 mirror in `maintel/SetupMTCS`:
```
asyncio.create_task(self.mtcs.raise_m1m3())
```
So it does not wait for the mirror to rise before sending new commands. Need to change it to 
```
await self.mtcs.raise_m1m3()
```
