### PR TITLE
Auxtel whitelight on /off scripts

### DIFF
--- a/python/lsst/ts/standardscripts/auxtel/__init__.py
+++ b/python/lsst/ts/standardscripts/auxtel/__init__.py
@@ -34,3 +34,4 @@ from .take_image_latiss import *
 from .take_stuttered_latiss import *
 from .track_target import *
 from .track_target_and_take_image import *
+from .whitelight_latiss_control import *

--- a/python/lsst/ts/standardscripts/auxtel/whitelight_latiss_control.py
+++ b/python/lsst/ts/standardscripts/auxtel/whitelight_latiss_control.py
@@ -1,0 +1,41 @@
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+from lsst.ts import salobj
+
+class WhiteLightControlScriptBase(salobj.BaseScript):
+    SCRIPT_DESCR_NAME: str = "BaseClass"
+    """ White Light Control script base class for Auxtel
+
+        This is a SAL script to control the functions of the auxtel
+        white light calibration system.
+
+        Until that is installed, in the meantime it will be able to control
+        the red LED dome flat projector on and off in auxtel"""
+
+
+    def __init__(self, index: int):
+        descr = f"Turn the auxtel White Light {self.SCRIPT_DESCR_NAME}"
+        super().__init__(index=index, descr=descr)
+
+        self._whitelight = salobj.Remote(self.domain, "ATWhiteLight")
+
+
+

--- a/python/lsst/ts/standardscripts/auxtel/whitelight_latiss_control.py
+++ b/python/lsst/ts/standardscripts/auxtel/whitelight_latiss_control.py
@@ -37,7 +37,7 @@ properties:
         default: 30
     lamp_power:
         description: Desired lamp power in Watts
-        type: float
+        type: number
         default: 1200
 """
 
@@ -72,7 +72,7 @@ class WhiteLightControlScriptBase(salobj.BaseScript):
         self._lamppower: float = config.lamp_power
 
     def set_metadata(self, metadata):
-        ...
+        pass
 
     async def run(self) -> None:
         # first check if ATWhiteLight is enabled

--- a/python/lsst/ts/standardscripts/auxtel/whitelight_latiss_control.py
+++ b/python/lsst/ts/standardscripts/auxtel/whitelight_latiss_control.py
@@ -19,6 +19,19 @@
 # You should have received a copy of the GNU General Public License
 
 from lsst.ts import salobj
+from typing import Dict
+from abc import abstractmethod
+from yaml import safe_load
+from types import SimpleNamespace
+
+_ATWhiteLightSchema = """
+$schema: http://json-schema.org/draft-07/schema#
+$id: TODOTODOTODO
+title: AuxtelWhiteLightControl{script_suffix} v1
+description: Control the auxtel white light system
+type: object
+additionalProperties: false
+"""
 
 class WhiteLightControlScriptBase(salobj.BaseScript):
     SCRIPT_DESCR_NAME: str = "BaseClass"
@@ -37,5 +50,29 @@ class WhiteLightControlScriptBase(salobj.BaseScript):
 
         self._whitelight = salobj.Remote(self.domain, "ATWhiteLight")
 
+    @classmethod
+    def get_schema(cls) -> Dict:
+        ourschema = _ATWhiteLightSchema.format(
+            script_suffix=cls.SCRIPT_DESCR_NAME.capitalize())
+        return safe_load(ourschema)
 
+    async def configure(self, config: SimpleNamespace):
+        #NOTE: as yet there are no configuration options worth checking!
+        pass
+
+    def set_metadata(self, metadata): ...
+
+    async def run(self) -> None: ...
+
+    @abstractmethod
+    async def _exec_whitelight_onoff_action(self) -> None: ...
+
+
+class WhiteLightControlScriptTurnOn(WhiteLightControlScriptBase):
+    SCRIPT_DESCR_NAME: str = "on"
+    async def _exec_whitelight_onoff_action(self) -> None: ...
+
+class WhiteLightControlScriptTurnOff(WhiteLightControlScriptBase):
+    SCRIPT_DESCR_NAME: str = "off"
+    async def _exec_whitelight_onoff_action(self) -> None: ...
 

--- a/python/lsst/ts/standardscripts/auxtel/whitelight_latiss_control.py
+++ b/python/lsst/ts/standardscripts/auxtel/whitelight_latiss_control.py
@@ -43,6 +43,7 @@ properties:
 
 _CSC_CMP_NAME = "ATWhiteLight"
 
+
 class WhiteLightControlScriptBase(salobj.BaseScript):
     SCRIPT_DESCR_NAME: str = "BaseClass"
     """ White Light Control script base class for Auxtel
@@ -53,7 +54,6 @@ class WhiteLightControlScriptBase(salobj.BaseScript):
         Until that is installed, in the meantime it will be able to control
         the red LED dome flat projector on and off in auxtel"""
 
-
     def __init__(self, index: int):
         descr = f"Turn the auxtel White Light {self.SCRIPT_DESCR_NAME}"
         super().__init__(index=index, descr=descr)
@@ -63,37 +63,44 @@ class WhiteLightControlScriptBase(salobj.BaseScript):
     @classmethod
     def get_schema(cls) -> Dict:
         ourschema = _ATWhiteLightSchema.format(
-            script_suffix=cls.SCRIPT_DESCR_NAME.capitalize())
+            script_suffix=cls.SCRIPT_DESCR_NAME.capitalize()
+        )
         return safe_load(ourschema)
 
     async def configure(self, config: SimpleNamespace):
         self._evttimeout: int = config.event_timeout
         self._lamppower: float = config.lamp_power
 
-    def set_metadata(self, metadata): ...
+    def set_metadata(self, metadata):
+        ...
 
     async def run(self) -> None:
-        #first check if ATWhiteLight is enabled
+        # first check if ATWhiteLight is enabled
         ss = await self._whitelight.evt_summaryState.aget(timeout=self._evttimeout)
         state = salobj.State(ss)
 
         if state != salobj.State.ENABLED:
-            raise AssertionError(f"{_CSC_CMP_NAME} needs to be enabled to run this script")
+            raise AssertionError(
+                f"{_CSC_CMP_NAME} needs to be enabled to run this script"
+            )
 
-        #now turn on (or off, depending on instantiation) the lamp
+        # now turn on (or off, depending on instantiation) the lamp
         await self._exec_whitelight_onoff_action()
 
     @abstractmethod
-    async def _exec_whitelight_onoff_action(self) -> None: ...
+    async def _exec_whitelight_onoff_action(self) -> None:
+        ...
 
 
 class WhiteLightControlScriptTurnOn(WhiteLightControlScriptBase):
     SCRIPT_DESCR_NAME: str = "on"
+
     async def _exec_whitelight_onoff_action(self) -> None:
         await self._whitelight.cmd_turnLampOn(self._lamppower)
 
+
 class WhiteLightControlScriptTurnOff(WhiteLightControlScriptBase):
     SCRIPT_DESCR_NAME: str = "off"
+
     async def _exec_whitelight_onoff_action(self) -> None:
         await self._whitelight.cmd_turnLampOff()
-

--- a/python/lsst/ts/standardscripts/data/scripts/auxtel/turn_white_light_off.py
+++ b/python/lsst/ts/standardscripts/data/scripts/auxtel/turn_white_light_off.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+import asyncio
+from lsst.ts.standardscripts.auxtel.whitelight_latiss_control import WhiteLightControlScriptTurnOff
+
+asyncio.run(WhiteLightControlScriptTurnOff.amain())

--- a/python/lsst/ts/standardscripts/data/scripts/auxtel/turn_white_light_off.py
+++ b/python/lsst/ts/standardscripts/data/scripts/auxtel/turn_white_light_off.py
@@ -20,6 +20,8 @@
 # You should have received a copy of the GNU General Public License
 
 import asyncio
-from lsst.ts.standardscripts.auxtel.whitelight_latiss_control import WhiteLightControlScriptTurnOff
+from lsst.ts.standardscripts.auxtel.whitelight_latiss_control import (
+    WhiteLightControlScriptTurnOff,
+)
 
 asyncio.run(WhiteLightControlScriptTurnOff.amain())

--- a/python/lsst/ts/standardscripts/data/scripts/auxtel/turn_white_light_on.py
+++ b/python/lsst/ts/standardscripts/data/scripts/auxtel/turn_white_light_on.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+import asyncio
+from lsst.ts.standardscripts.auxtel.whitelight_latiss_control import WhiteLightControlScriptTurnOn
+
+asyncio.run(WhiteLightControlScriptTurnOn.amain())

--- a/python/lsst/ts/standardscripts/data/scripts/auxtel/turn_white_light_on.py
+++ b/python/lsst/ts/standardscripts/data/scripts/auxtel/turn_white_light_on.py
@@ -20,6 +20,8 @@
 # You should have received a copy of the GNU General Public License
 
 import asyncio
-from lsst.ts.standardscripts.auxtel.whitelight_latiss_control import WhiteLightControlScriptTurnOn
+from lsst.ts.standardscripts.auxtel.whitelight_latiss_control import (
+    WhiteLightControlScriptTurnOn,
+)
 
 asyncio.run(WhiteLightControlScriptTurnOn.amain())

--- a/tests/test_auxtel_whitelight_control.py
+++ b/tests/test_auxtel_whitelight_control.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 import logging
 import unittest
 from typing import Optional
-from contextlib import asynccontextmanager
 
 from lsst.ts.standardscripts.auxtel import (
     WhiteLightControlScriptTurnOn,
@@ -44,9 +43,9 @@ class TestAuxtelWhiteLightScripts(
     TEST_TIMEOUT_VALUE: int = 35
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args,**kwargs)
+        super().__init__(*args, **kwargs)
         self._lamp_state: Optional[bool] = None
-        
+
     # NOTE the below is overriding base class with different
     # signature, is that OK??
     async def basic_make_script(self, index: int):
@@ -92,6 +91,7 @@ class TestAuxtelWhiteLightScripts(
                         assert self._lamp_state is False
                     case auxtel.WhiteLightControlScriptTurnOn:
                         assert self._lamp_state is True
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_auxtel_whitelight_control.py
+++ b/tests/test_auxtel_whitelight_control.py
@@ -18,12 +18,14 @@
 #
 # You should have received a copy of the GNU General Public License
 
-import asyncio
 import logging
 import unittest
 from typing import Optional
 
-from lsst.ts.standardscripts.auxtel import WhiteLightControlScriptTurnOn, WhiteLightControlScriptTurnOff
+from lsst.ts.standardscripts.auxtel import (
+    WhiteLightControlScriptTurnOn,
+    WhiteLightControlScriptTurnOff,
+)
 from lsst.ts import standardscripts
 from lsst.ts.standardscripts import auxtel
 from lsst.ts import salobj
@@ -31,17 +33,20 @@ from lsst.ts import salobj
 
 logging.basicConfig(level=logging.DEBUG)
 
+
 class TestAuxtelWhiteLightScripts(
-        standardscripts.BaseScriptTestCase, unittest.IsolatedAsyncioTestCase):
+    standardscripts.BaseScriptTestCase, unittest.IsolatedAsyncioTestCase
+):
     TEST_SCRIPTS = [WhiteLightControlScriptTurnOff, WhiteLightControlScriptTurnOn]
-    TEST_POWER_VALUE: float = 800.
+    TEST_POWER_VALUE: float = 800.0
     TEST_TIMEOUT_VALUE: int = 35
 
     def __init__(self):
         self._lamp_state: Optional[bool] = None
 
-    #NOTE the below is overriding base class with different signature, is that OK??
-    async def basic_make_script(self, index:int, scripttp: salobj.BaseScript):
+    # NOTE the below is overriding base class with different
+    # signature, is that OK??
+    async def basic_make_script(self, index: int, scripttp: salobj.BaseScript):
         self.script = scripttp(index)
         self.atwhitelight = salobj.Controller(name="ATWhiteLight")
 
@@ -60,32 +65,25 @@ class TestAuxtelWhiteLightScripts(
 
         for sc in self.TEST_SCRIPTS:
             async with self.basic_make_script(1, sc):
-                await self.configure_script(lamp_power=self.TEST_POWER_VALUE,
-                                            event_timeout=self.TEST_TIMEOUT_VALUE)
+                await self.configure_script(
+                    lamp_power=self.TEST_POWER_VALUE,
+                    event_timeout=self.TEST_TIMEOUT_VALUE,
+                )
 
                 assert self.script._evttimeout == self.TEST_TIMEOUT_VALUE
                 assert self.script._lamppower == self.TEST_POWER_VALUE
 
-
     async def test_run(self):
         for sc in self.TEST_SCRIPTS:
             async with self.basic_make_script(1, sc) as (script, whitelight):
-                await self.configure_script(lamp_power=self.TEST_POWER_VALUE,
-                                            event_timeout=self.TEST_TIMEOUT_VALUE)
+                await self.configure_script(
+                    lamp_power=self.TEST_POWER_VALUE,
+                    event_timeout=self.TEST_TIMEOUT_VALUE,
+                )
 
                 await self.run_script()
                 match type(sc):
                     case auxtel.WhiteLightControlScriptTurnOff:
-                        assert self._lamp_state == False
+                        assert self._lamp_state is False
                     case auxtel.WhiteLightControlScriptTurnOn:
-                        assert self._lamp_state == True
-
-
-
-
-
-
-
-
-
-
+                        assert self._lamp_state is True

--- a/tests/test_auxtel_whitelight_control.py
+++ b/tests/test_auxtel_whitelight_control.py
@@ -1,0 +1,90 @@
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+import asyncio
+import logging
+import unittest
+from typing import Optional
+
+from lsst.ts.standardscripts.auxtel import WhiteLightControlScriptTurnOn, WhiteLightControlScriptTurnOff
+from lsst.ts import standardscripts
+from lsst.ts import salobj
+
+
+logging.basicConfig(level=logging.DEBUG)
+
+class TestAuxtelWhiteLightScripts(
+        standardscripts.BaseScriptTestCase, unittest.IsolatedAsyncioTestCase):
+    TEST_SCRIPTS = [WhiteLightControlScriptTurnOff, WhiteLightControlScriptTurnOn]
+    TEST_POWER_VALUE: float = 800.
+    TEST_TIMEOUT_VALUE: int = 35
+
+    def __init__(self):
+        self._lamp_state: Optional[bool] = None
+
+    #NOTE the below is overriding base class with different signature, is that OK??
+    async def basic_make_script(self, index:int, scripttp: salobj.BaseScript):
+        self.script = scripttp(index)
+        self.atwhitelight = salobj.Controller(name="ATWhiteLight")
+
+        self.atwhitelight.cmd_turnLampOn.callback = self.cmd_turnon_callback
+        self.atwhitelight.cmd_turnLampOff.callbacj = self.cmd_turnoff_callback
+
+        return self.script, self.atwhitelight
+
+    async def cmd_turnon_callback(self):
+        self._lamp_state = True
+
+    async def cmd_turnoff_callback(self):
+        self._lamp_state = False
+
+    async def test_configure(self):
+
+        for sc in self.TEST_SCRIPTS:
+            async with self.basic_make_script(1, sc):
+                await self.configure_script(lamp_power=self.TEST_POWER_VALUE,
+                                            event_timeout=self.TEST_TIMEOUT_VALUE)
+
+                assert self.script._evttimeout == self.TEST_TIMEOUT_VALUE
+                assert self.script._lamppower == self.TEST_POWER_VALUE
+
+
+    async def test_run(self):
+        for sc in self.TEST_SCRIPTS:
+            async with self.basic_make_script(1, sc) as (script, whitelight):
+                await self.configure_script(lamp_power=self.TEST_POWER_VALUE,
+                                            event_timeout=self.TEST_TIMEOUT_VALUE)
+
+                await self.run_script()
+                match sc:
+                    case WhiteLightControlScriptTurnOff:
+                        assert self._lamp_state == False
+                    case WhiteLightControlScriptTurnOn:
+                        assert self._lamp_state == True
+
+
+
+
+
+
+
+
+
+

--- a/tests/test_auxtel_whitelight_control.py
+++ b/tests/test_auxtel_whitelight_control.py
@@ -41,6 +41,7 @@ class TestAuxtelWhiteLightScripts(
     TEST_SCRIPTS = [WhiteLightControlScriptTurnOff, WhiteLightControlScriptTurnOn]
     TEST_POWER_VALUE: float = 800.0
     TEST_TIMEOUT_VALUE: int = 35
+    TEST_CHILLER_TURNON_VALUE: float = 120.0
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -71,10 +72,12 @@ class TestAuxtelWhiteLightScripts(
                 await self.configure_script(
                     lamp_power=self.TEST_POWER_VALUE,
                     event_timeout=self.TEST_TIMEOUT_VALUE,
+                    chiller_turnon_wait=self.TEST_CHILLER_TURNON_VALUE,
                 )
 
-                assert self.script._evttimeout == self.TEST_TIMEOUT_VALUE
-                assert self.script._lamppower == self.TEST_POWER_VALUE
+                assert self.script.event_timeout == self.TEST_TIMEOUT_VALUE
+                assert self.script.lamp_power == self.TEST_POWER_VALUE
+                assert self.script.chiller_turnon_wait == self.TEST_CHILLER_TURNON_VALUE
 
     async def test_run(self):
         for sc in self.TEST_SCRIPTS:
@@ -83,6 +86,7 @@ class TestAuxtelWhiteLightScripts(
                 await self.configure_script(
                     lamp_power=self.TEST_POWER_VALUE,
                     event_timeout=self.TEST_TIMEOUT_VALUE,
+                    chilller_turnon_wait=self.TEST_CHILLER_TURNON_VALUE
                 )
 
                 await self.run_script()

--- a/tests/test_auxtel_whitelight_control.py
+++ b/tests/test_auxtel_whitelight_control.py
@@ -25,6 +25,7 @@ from typing import Optional
 
 from lsst.ts.standardscripts.auxtel import WhiteLightControlScriptTurnOn, WhiteLightControlScriptTurnOff
 from lsst.ts import standardscripts
+from lsst.ts.standardscripts import auxtel
 from lsst.ts import salobj
 
 
@@ -73,10 +74,10 @@ class TestAuxtelWhiteLightScripts(
                                             event_timeout=self.TEST_TIMEOUT_VALUE)
 
                 await self.run_script()
-                match sc:
-                    case WhiteLightControlScriptTurnOff:
+                match type(sc):
+                    case auxtel.WhiteLightControlScriptTurnOff:
                         assert self._lamp_state == False
-                    case WhiteLightControlScriptTurnOn:
+                    case auxtel.WhiteLightControlScriptTurnOn:
                         assert self._lamp_state == True
 
 


### PR DESCRIPTION
this is not intended to be merged. It is a PR solely so that @tribeiro  can tell me everything that's wrong with it.

This is a basic set of 2 scripts to turn on and off the ATWhiteLight system in a SAL script. Included also is a trivial test case