### PR TITLE
Tickets/sitcom 482 - Create script to track and take image for MT and GenericCamera

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,12 @@
 Version History
 ===============
 
+v1.15.4
+-------
+
+* Add maintel/track_target_and_take_image_comcam.py with new ``TrackTargetAndTakeImageGenCam``. 
+* Add unit tests for ``TrackTargetAndTakeImageGenCam``
+
 v1.15.3
 -------
 

--- a/python/lsst/ts/standardscripts/data/scripts/maintel/track_target_and_take_image_gencam.py
+++ b/python/lsst/ts/standardscripts/data/scripts/maintel/track_target_and_take_image_gencam.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # This file is part of ts_standardscripts
 #
 # Developed for the LSST Telescope and Site Systems.
@@ -18,15 +19,8 @@
 #
 # You should have received a copy of the GNU General Public License
 
-from .enable_comcam import *
-from .enable_mtcs import *
-from .offline_comcam import *
-from .offline_mtcs import *
-from .setup_mtcs import *
-from .standby_comcam import *
-from .standby_mtcs import *
-from .stop import *
-from .take_image_comcam import *
-from .track_target import *
-from .track_target_and_take_image_comcam import *
-from .track_target_and_take_image_gencam import *
+import asyncio
+
+from lsst.ts.standardscripts.maintel import TrackTargetAndTakeImageComCam
+
+asyncio.run(TrackTargetAndTakeImageComCam.amain())

--- a/python/lsst/ts/standardscripts/maintel/track_target_and_take_image_gencam.py
+++ b/python/lsst/ts/standardscripts/maintel/track_target_and_take_image_gencam.py
@@ -1,0 +1,147 @@
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+__all__ = ["TrackTargetAndTakeImageGenCam"]
+
+import asyncio
+
+from ..base_track_target_and_take_image import BaseTrackTargetAndTakeImage
+
+from lsst.ts.observatory.control import Usages
+from lsst.ts.observatory.control.utils import RotType
+from lsst.ts.observatory.control.maintel.mtcs import MTCS, MTCSUsages
+from lsst.ts.observatory.control.generic_camera import GenericCamera
+
+
+class TrackTargetAndTakeImageGenCam(BaseTrackTargetAndTakeImage):
+    """Track target and take image script.
+
+    This script implements a simple visit consistig of slewing to a target,
+    start tracking and take image.
+
+    Parameters
+    ----------
+    index : `int`
+        Index of Script SAL component.
+    add_remotes : `bool` (optional)
+        Create remotes to control components (default: `True`)? If False, the
+        script will not work for normal operations. Useful for unit testing.
+    """
+
+    def __init__(self, index, add_remotes: bool = True):
+        super().__init__(
+            index=index, descr="Track target and take image with MainTel and ComCam."
+        )
+
+        # Is there a better way to define this?
+        Usages.TakeImageFull = 1 << 4
+
+        self.mtcs_usage, self.gencam_usage = (
+            (MTCSUsages.Slew, Usages.TakeImageFull)
+            if add_remotes
+            else (MTCSUsages.DryTest, Usages.DryTest)
+        )
+
+        self.mtcs = MTCS(self.domain, intended_usage=self.mtcs_usage, log=self.log)
+        self.gencam = None
+
+    async def load_playlist(self):
+        """Load playlist."""
+        raise NotImplementedError()
+
+    async def assert_feasibility(self):
+        """Verify that the system is in a feasible state to execute the
+        script.
+        """
+        await asyncio.gather(
+            self.mtcs.assert_all_enabled(),
+            self.mtcs.assert_liveliness(),
+            self.gencam.assert_all_enabled(),
+            self.gencam.assert_liveliness(),
+        )
+
+    async def configure(self, config):
+        await super().configure(config)
+        self.gencam = GenericCamera(
+            self.config.camera_index,
+            self.domain,
+            intended_usage=self.gencam_usage,
+            log=self.log,
+        )
+
+    @classmethod
+    def get_schema(cls):
+
+        schema_dict = cls.get_base_schema()
+        schema_dict[
+            "$id"
+        ] = "https://github.com/lsst-ts/ts_standardscripts/maintel/track_target_and_take_image_gencam.py"
+        schema_dict["title"] = "TrackTargetAndTakeImageGenCam v1"
+        schema_dict["description"] = "Configuration for TrackTargetAndTakeImageGenCam."
+
+        schema_dict["camera_index"] = dict(
+            type="integer",
+            description="SAL Index for the Generic Camera.",
+            minimum=0,
+            maximum=2147483647,
+        )
+
+        schema_dict["required"].append("camera_index")
+        schema_dict["required"].remove("band_filter")
+
+        return schema_dict
+
+    async def track_target_and_setup_instrument(self):
+        """Track target and setup instrument in parallel."""
+
+        self.tracking_started = True
+
+        await self.mtcs.slew_icrs(
+            ra=self.config.ra,
+            dec=self.config.dec,
+            rot=self.config.rot_sky,
+            rot_type=RotType.Sky,
+            target_name=self.config.name,
+        )
+
+    async def take_data(self):
+        """Take data while making sure ATCS is tracking."""
+
+        tasks = [
+            asyncio.create_task(self._take_data()),
+            asyncio.create_task(self.mtcs.check_tracking()),
+        ]
+
+        await self.mtcs.process_as_completed(tasks)
+
+    async def _take_data(self):
+        """Take data."""
+
+        for exptime in self.config.exp_times:
+            await self.gencam.take_object(
+                exptime=exptime,
+                group_id=self.group_id,
+                reason=self.config.reason,
+                program=self.config.program,
+            )
+
+    async def stop_tracking(self):
+        """Execute stop tracking on MTCS."""
+        await self.mtcs.stop_tracking()

--- a/tests/test_maintel_track_target_and_take_image_gencam.py
+++ b/tests/test_maintel_track_target_and_take_image_gencam.py
@@ -1,0 +1,253 @@
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+import asyncio
+import copy
+import types
+import numpy
+import random
+import logging
+import unittest
+import contextlib
+
+import pytest
+
+from lsst.ts import salobj
+from lsst.ts.observatory.control.utils import RotType
+from lsst.ts import standardscripts
+from lsst.ts.standardscripts.maintel.track_target_and_take_image_gencam import (
+    TrackTargetAndTakeImageGenCam,
+)
+
+random.seed(42)  # for set_random_lsst_dds_partition_prefix
+
+logging.basicConfig()
+
+
+class TestMainTelTrackTargetAndTakeImageGenCam(
+    standardscripts.BaseScriptTestCase, unittest.IsolatedAsyncioTestCase
+):
+    """Test Main Telescope track target and take image with ComCam script.
+
+    Both AT and MT Slew scripts uses the same base script class. This unit
+    test performs the basic checks on Script integrity. For a more detailed
+    unit testing routine check the MT version.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.log = logging.getLogger("TestMainTelTrackTargetAndTakeImageComCam")
+        return super().setUpClass()
+
+    def setUp(self) -> None:
+        self.rotator_position = 0.0  # deg
+        self.rotator_velocity = 10.0  # deg/s
+        self.rot_sky_emulate_zero = 45.0
+        self._handle_slew_calls = 0
+        self._fail_handle_slew_after = 0
+        return super().setUp()
+
+    async def basic_make_script(self, index):
+        self.script = TrackTargetAndTakeImageGenCam(index=index, add_remotes=False)
+        return (self.script,)
+
+    async def check_tracking_fail_after_1s_side_effect(self):
+        self.log.debug("Wait 1 second and raise runtime error.")
+        await asyncio.sleep(1.0)
+        raise RuntimeError("Check tracking failed.")
+
+    async def check_tracking_forever_side_effect(self):
+        """Emulates a check tracking routine."""
+        self.log.debug("Wait for ever.")
+        future = asyncio.Future()
+        await future
+
+    async def configure_script_full(self):
+        configuration_full = dict(
+            targetid=10,
+            ra="10:00:00",
+            dec="-10:00:00",
+            rot_sky=0.0,
+            name="unit_test_target",
+            obs_time=7.0,
+            estimated_slew_time=5.0,
+            num_exp=2,
+            exp_times=[2.0, 1.0],
+            reason="Unit testing",
+            program="UTEST",
+            camera_index=random.randint(1, 10),
+        )
+
+        await self.configure_script(**configuration_full)
+
+        return configuration_full
+
+    async def get_rotator_position(self, flush, timeout):
+        if flush:
+            await asyncio.sleep(timeout / 2.0)
+        return types.SimpleNamespace(actualPosition=self.rotator_position)
+
+    async def handle_slew_icrs(
+        self,
+        ra,
+        dec,
+        rot,
+        rot_type,
+        target_name,
+    ):
+        self._handle_slew_calls += 1
+        if (
+            self._fail_handle_slew_after > 0
+            and self._handle_slew_calls > self._fail_handle_slew_after
+        ):
+            raise RuntimeError(
+                f"Failing slew after {self._fail_handle_slew_after} calls."
+            )
+        await asyncio.sleep(0.5)
+        if rot_type == RotType.Physical:
+            self.log.debug(f"Slew with rot_type = {RotType.Physical!r}")
+            rotator_velocity = self.rotator_velocity * (
+                1.0 if rot > self.rotator_position else -1.0
+            )
+            rotator_positions = numpy.arange(
+                self.rotator_position, rot, rotator_velocity
+            )
+            for _rot in rotator_positions:
+                self.log.debug(f"Rotator position: {self.rotator_position} -> {_rot}")
+                self.rotator_position = _rot
+                await asyncio.sleep(1.0)
+            self.rotator_position = rot
+        else:
+            self.rotator_position = rot + self.rot_sky_emulate_zero
+        await asyncio.sleep(0.5)
+
+    @contextlib.asynccontextmanager
+    async def setup_mocks(self):
+        self.script.mtcs.slew_icrs = unittest.mock.AsyncMock(
+            side_effect=self.handle_slew_icrs
+        )
+        self.script.mtcs.stop_tracking = unittest.mock.AsyncMock()
+        self.script.mtcs.check_tracking = unittest.mock.AsyncMock()
+        self.script.mtcs.rem = types.SimpleNamespace(
+            mtrotator=unittest.mock.AsyncMock()
+        )
+        self.script.gencam.take_object = unittest.mock.AsyncMock(
+            side_effect=self.take_object_side_effect
+        )
+
+        self.script.mtcs.rem.mtrotator.configure_mock(
+            **{"tel_rotation.next.side_effect": self.get_rotator_position}
+        )
+
+        yield
+
+    async def take_object_side_effect(
+        self,
+        exptime,
+        group_id,
+        reason,
+        program,
+    ):
+
+        self.log.debug(
+            f"exptime: {exptime}s, group_id: {group_id}, reason: {reason}, program: {program}"
+        )
+        await asyncio.sleep(exptime)
+
+    async def test_configure(self):
+        async with self.make_script():
+
+            configuration_full = await self.configure_script_full()
+
+            for key in configuration_full:
+                assert configuration_full[key] == getattr(self.script.config, key)
+
+            required_fields = {
+                "ra",
+                "dec",
+                "rot_sky",
+                "name",
+                "obs_time",
+                "num_exp",
+                "exp_times",
+                "camera_index",
+            }
+
+            for required_field in required_fields:
+                bad_configuration = copy.deepcopy(configuration_full)
+                bad_configuration.pop(required_field)
+                with pytest.raises(salobj.ExpectedError):
+                    await self.configure_script(**bad_configuration)
+
+    async def test_executable(self):
+        scripts_dir = standardscripts.get_scripts_dir()
+        script_path = scripts_dir / "auxtel" / "track_target_and_take_image.py"
+        await self.check_executable(script_path)
+
+    async def test_run_fail_check_tracking(self):
+
+        async with self.make_script():
+
+            # New GemCam is stanciated during configuration
+            configuration_full = await self.configure_script_full()
+
+            async with self.setup_mocks():
+
+                self.script.mtcs.check_tracking.side_effect = (
+                    self.check_tracking_fail_after_1s_side_effect
+                )
+
+                self.rotator_position = -15.0
+
+                with pytest.raises(AssertionError):
+                    await self.run_script()
+
+                slew_icrs_expected_calls = [
+                    unittest.mock.call(
+                        ra=configuration_full["ra"],
+                        dec=configuration_full["dec"],
+                        rot=configuration_full["rot_sky"],
+                        rot_type=RotType.Sky,
+                        target_name=configuration_full["name"],
+                    ),
+                ]
+
+                self.script.mtcs.slew_icrs.assert_has_awaits(slew_icrs_expected_calls)
+
+                gencam_take_object_calls = [
+                    unittest.mock.call(
+                        exptime=configuration_full["exp_times"][0],
+                        group_id=self.script.group_id,
+                        reason=configuration_full["reason"],
+                        program=configuration_full["program"],
+                    )
+                ]
+
+                self.script.gencam.take_object.assert_has_awaits(
+                    gencam_take_object_calls
+                )
+
+                self.script.mtcs.check_tracking.assert_awaited_once()
+
+                self.script.mtcs.stop_tracking.assert_awaited_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implement track_target_and_take_image in ts_standardscripts. This will be one of the scripts used for the TMA Pointing and Track Verification. Use the existing [track_target_and_take_image_comcam](https://github.com/lsst-ts/ts_standardscripts/blob/develop/python/lsst/ts/standardscripts/maintel/track_target_and_take_image_comcam.py) as a reference.