### PR TITLE
Tickets/sitcom 750 - Raise M1M3

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -10,6 +10,7 @@ v1.20.0
 -------
 
 * Add new ``auxtel/latiss_take_sequence.py`` script, unit tests, and executables
+* Add new ``maintel/m1m3/raise_m1m3.py`` to raise MainTel M1M3 mirror. 
 
 v1.19.2
 -------

--- a/python/lsst/ts/standardscripts/data/scripts/maintel/m1m3/raise_m1m3.py
+++ b/python/lsst/ts/standardscripts/data/scripts/maintel/m1m3/raise_m1m3.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+import asyncio
+
+from lsst.ts.standardscripts.maintel.m1m3 import RaiseM1M3
+
+asyncio.run(RaiseM1M3.amain())

--- a/python/lsst/ts/standardscripts/maintel/m1m3/__init__.py
+++ b/python/lsst/ts/standardscripts/maintel/m1m3/__init__.py
@@ -1,0 +1,21 @@
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+from .raise_m1m3 import *

--- a/python/lsst/ts/standardscripts/maintel/m1m3/raise_m1m3.py
+++ b/python/lsst/ts/standardscripts/maintel/m1m3/raise_m1m3.py
@@ -1,0 +1,75 @@
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+__all__ = ["RaiseM1M3"]
+
+import time
+
+from lsst.ts.observatory.control.maintel.mtcs import MTCS, MTCSUsages
+
+from lsst.ts import salobj
+
+
+class RaiseM1M3(salobj.BaseScript):
+    """Raise M1M3 mirror.
+
+    Parameters
+    ----------
+    index : `int`
+        Index of Script SAL component.
+
+    Notes
+    -----
+    **Checkpoints**
+
+    - "Raising M1M3": Before commanding the M1M3 mirror to raise.
+
+    **Details**
+
+    This script raises the M1M3 mirror of the Simonyi Main Telescope.
+
+
+    """
+
+    def __init__(self, index, add_remotes: bool = True):
+        super().__init__(index=index, descr="Raise M1M3")
+
+        mtcs_usage = None if add_remotes else MTCSUsages.DryTest
+
+        self.mtcs = MTCS(self.domain, intended_usage=mtcs_usage, log=self.log)
+
+    @classmethod
+    def get_schema(cls):
+        return None
+
+    async def configure(self, config):
+        # This script does not require any configuration.
+        pass
+
+    def set_metadata(self, metadata):
+        metadata.duration = 180.0
+
+    async def run(self):
+        await self.checkpoint("Raising M1M3")
+        start_time = time.time()
+        await self.mtcs.raise_m1m3()
+        end_time = time.time()
+        elapsed_time = end_time - start_time
+        self.log.info(f"M1M3 Raise took {elapsed_time:.2f} seconds")

--- a/tests/test_maintel_raise_m1m3.py
+++ b/tests/test_maintel_raise_m1m3.py
@@ -1,0 +1,51 @@
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+import unittest
+
+from lsst.ts import standardscripts
+from lsst.ts.standardscripts.maintel.m1m3 import RaiseM1M3
+
+
+class TestRaiseM1M3(
+    standardscripts.BaseScriptTestCase, unittest.IsolatedAsyncioTestCase
+):
+    async def basic_make_script(self, index):
+        self.script = RaiseM1M3(index=index, add_remotes=False)
+        self.script.mtcs.raise_m1m3 = unittest.mock.AsyncMock()
+
+        return (self.script,)
+
+    async def test_run(self):
+        async with self.make_script():
+            await self.configure_script()
+
+            await self.run_script()
+            self.script.mtcs.raise_m1m3.assert_awaited_once()
+
+    async def test_executable(self):
+        scripts_dir = standardscripts.get_scripts_dir()
+        script_path = scripts_dir / "maintel" / "m1m3" / "raise_m1m3.py"
+        print(script_path)
+        await self.check_executable(script_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hi Tiago, Bruno, 
I tested the script in the TTS MTQueue and the script works well. 

The unitest `test_run` gets stuck if it tries to execute the `run_script()`, that's why it's commented out. Otherwise, it completes the unites with some warnings but no errors. 
Also, the list of available scripts that the MTQueue shows now contains another `raise_m1m3` from a different location, `/maintel/raise_m1m3.py` instead of `maintel/m1m3/raise_m1m3.py`, file that I have erased but still shows listed in the MTQueue. 

Thank you for your time! Cheers, 
Ioana