### PR TITLE
Make SAL Script to mute watcher alarm

### DIFF
--- a/doc/news/DM-41610.feature.rst
+++ b/doc/news/DM-41610.feature.rst
@@ -1,0 +1,1 @@
+Add new `mute_alarms` SAL Script.

--- a/python/lsst/ts/standardscripts/data/scripts/mute_alarms.py
+++ b/python/lsst/ts/standardscripts/data/scripts/mute_alarms.py
@@ -1,4 +1,5 @@
-# This file is part of ts_standardscripts.
+#!/usr/bin/env python
+# This file is part of ts_standardscripts
 #
 # Developed for the LSST Telescope and Site Systems.
 # This product includes software developed by the LSST Project
@@ -17,23 +18,10 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-from .base_block_script import *
-from .base_point_azel import *
-from .base_script_test_case import *
-from .mute_alarms import *
-from .pause_queue import *
-from .run_command import *
-from .set_summary_state import *
-from .sleep import *
-from .system_wide_shutdown import *
-from .utils import *
+import asyncio
 
-try:
-    from .version import *
-except ImportError:
-    __version__ = "?"
-    __repo_version__ = "?"
-    __fingerprint__ = "? *"
-    __dependency_versions__ = {}
+from lsst.ts.standardscripts import MuteAlarms
+
+asyncio.run(MuteAlarms.amain())

--- a/python/lsst/ts/standardscripts/mute_alarms.py
+++ b/python/lsst/ts/standardscripts/mute_alarms.py
@@ -1,0 +1,117 @@
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+__all__ = ["MuteAlarms"]
+
+import yaml
+from lsst.ts import salobj
+from lsst.ts.xml.enums.Watcher import AlarmSeverity
+
+
+class MuteAlarms(salobj.BaseScript):
+    """
+    Mute Watcher alarm(s) for a given amount of time.
+
+    Parameters
+    ----------
+    index : `int`
+        Index of Script SAL component.
+    """
+
+    def __init__(self, index):
+        super().__init__(
+            index=index, descr="Mute Watcher alarm(s) for a given amount of time."
+        )
+        self.watcher = None
+        self.std_timeout = 60.0
+
+    @classmethod
+    def get_schema(cls):
+        schema_yaml = f"""
+            $schema: http://json-schema.org/draft-07/schema#
+            $id: https://github.com/lsst-ts/ts_standardscripts/sleep.yaml
+            title: MuteAlarms v1
+            description: Configuration for MuteAlarms command.
+            type: object
+            properties:
+                name:
+                    description: >-
+                        Name of alarm or alarms to mute.
+                        Specify a regular expression for multiple alarms.
+                    type: string
+                mutedBy:
+                    description: User who muted the alarm(s).
+                    type: string
+                duration:
+                    description: Duration of the mute command in seconds.
+                    type: number
+                    minimum: 0
+                    default: 300
+                severity:
+                    description: >-
+                        Severity level being muted.
+                        An AlarmSeverity enum.
+                    type: string
+                    enum: {[e.name for e in AlarmSeverity]}
+                    default: "None"
+            additionalProperties: false
+            required:
+                - name
+                - mutedBy
+                - duration
+                - severity
+        """
+        return yaml.safe_load(schema_yaml)
+
+    async def configure(self, config):
+        """Configure the script.
+
+        Parameters
+        ----------
+        config : `types.SimpleNamespace`
+            Configuration
+        """
+        self.name = config.name
+        self.mutedBy = config.mutedBy
+        self.duration = config.duration
+        self.severity = AlarmSeverity[config.severity]
+
+        # Create the Watcher remote
+        if self.watcher is None:
+            self.watcher = salobj.Remote(
+                domain=self.domain,
+                name="Watcher",
+            )
+            await self.watcher.start_task
+
+    def set_metadata(self, metadata):
+        metadata.duration = self.duration
+
+    async def run(self):
+        """Run the script."""
+        self.log.info(f"Muting alarm(s) {self.name} for {self.duration} seconds.")
+        await self.watcher.cmd_mute.set_start(
+            name=self.name,
+            duration=self.duration,
+            severity=self.severity,
+            mutedBy=self.mutedBy,
+            timeout=self.std_timeout,
+        )

--- a/tests/test_mute_alarms.py
+++ b/tests/test_mute_alarms.py
@@ -1,0 +1,86 @@
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import types
+import unittest
+
+from lsst.ts.standardscripts import BaseScriptTestCase, get_scripts_dir
+from lsst.ts.standardscripts.mute_alarms import MuteAlarms
+from lsst.ts.xml.enums.Watcher import AlarmSeverity
+
+
+class TestMuteAlarms(BaseScriptTestCase, unittest.IsolatedAsyncioTestCase):
+    async def basic_make_script(self, index):
+        self.script = MuteAlarms(index=index)
+        self.script.watcher = unittest.mock.AsyncMock()
+        return (self.script,)
+
+    async def test_configure(self):
+        async with self.make_script():
+            config = types.SimpleNamespace(
+                name=".*",
+                mutedBy="test",
+                duration=10,
+                severity="WARNING",
+            )
+            await self.script.configure(config)
+            pass
+
+    async def test_run(self):
+        """
+        Test that the script is paused for the selected queue.
+        """
+        async with self.make_script():
+            config = types.SimpleNamespace(
+                name=".*",
+                mutedBy="test",
+                duration=10,
+                severity="WARNING",
+            )
+
+            # Configure the script
+            await self.configure_script(
+                name=config.name,
+                mutedBy=config.mutedBy,
+                duration=config.duration,
+                severity=config.severity,
+            )
+
+            # Run the script
+            await self.run_script()
+
+            # Assert the command was called properly
+            self.script.watcher.cmd_mute.set_start.assert_awaited_with(
+                name=config.name,
+                duration=config.duration,
+                severity=AlarmSeverity[config.severity],
+                mutedBy=config.mutedBy,
+                timeout=self.script.std_timeout,
+            )
+
+    async def test_executable(self):
+        scripts_dir = get_scripts_dir()
+        script_path = scripts_dir / "pause_queue.py"
+        await self.check_executable(script_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Create a SAL Script with the same inputs as `Watcher.cmd_mute`. 