### PR TITLE
tickets/DM-44629: Add SAL Script to enable ATAOS corrections

### DIFF
--- a/doc/news/DM-44629.feature.rst
+++ b/doc/news/DM-44629.feature.rst
@@ -1,0 +1,1 @@
+Add `EnableATAOSCorrections` SAL script for `auxtel`.

--- a/python/lsst/ts/standardscripts/auxtel/enable_ataos_corrections.py
+++ b/python/lsst/ts/standardscripts/auxtel/enable_ataos_corrections.py
@@ -1,0 +1,93 @@
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__all__ = ["EnableATAOSCorrections"]
+
+import yaml
+from lsst.ts import salobj
+from lsst.ts.observatory.control.auxtel import ATCS, ATCSUsages
+
+
+class EnableATAOSCorrections(salobj.BaseScript):
+    """Enable ATAOS corrections as a stand alone operation.
+
+    Parameters
+    ----------
+    index : `int`
+        Index of Script SAL component.
+
+    """
+
+    def __init__(self, index):
+        super().__init__(
+            index=index,
+            descr="Enable ATAOS corrections.",
+        )
+
+        self.atcs = ATCS(
+            domain=self.domain, intended_usage=ATCSUsages.All, log=self.log
+        )
+
+    @classmethod
+    def get_schema(cls):
+        schema_yaml = """
+            $schema: http://json-schema.org/draft-07/schema#
+            $id: https://github.com/lsst-ts/ts_standardscripts/auxtel/enable_ataos_corrections.yaml
+            title: EnableATAOSCorrections v1
+            description: Configuration for EnableATAOSCorrections.
+            type: object
+            properties:
+                ignore:
+                    description: ATCS components to ignore in availability check.
+                    type: array
+                    items:
+                        type: string
+            additionalProperties: false
+        """
+        return yaml.safe_load(schema_yaml)
+
+    async def configure(self, config):
+        """Configure script.
+
+        Parameters
+        ----------
+        config : `types.SimpleNamespace`
+            Script configuration, as defined by `schema`.
+        """
+        self.config = config
+
+        if hasattr(self.config, "ignore"):
+            for comp in self.config.ignore:
+                if comp not in self.atcs.components_attr:
+                    self.log.warning(
+                        f"Component {comp} not in ATCS. "
+                        f"Must be one of {self.atcs.components_attr}. Ignoring."
+                    )
+                else:
+                    self.log.debug(f"Ignoring component {comp}.")
+                    setattr(self.atcs.check, comp, False)
+
+    def set_metadata(self, metadata):
+        pass
+
+    async def run(self):
+        await self.atcs.assert_all_enabled()
+        await self.atcs.enable_ataos_corrections()

--- a/python/lsst/ts/standardscripts/auxtel/enable_ataos_corrections.py
+++ b/python/lsst/ts/standardscripts/auxtel/enable_ataos_corrections.py
@@ -42,9 +42,7 @@ class EnableATAOSCorrections(salobj.BaseScript):
             descr="Enable ATAOS corrections.",
         )
 
-        self.atcs = ATCS(
-            domain=self.domain, intended_usage=ATCSUsages.All, log=self.log
-        )
+        self.atcs = None
 
     @classmethod
     def get_schema(cls):
@@ -73,6 +71,12 @@ class EnableATAOSCorrections(salobj.BaseScript):
             Script configuration, as defined by `schema`.
         """
         self.config = config
+
+        if self.atcs is None:
+            self.atcs = ATCS(
+                domain=self.domain, intended_usage=ATCSUsages.All, log=self.log
+            )
+            await self.atcs.start_task
 
         if hasattr(self.config, "ignore"):
             for comp in self.config.ignore:

--- a/python/lsst/ts/standardscripts/data/scripts/auxtel/enable_ataos_corrections.py
+++ b/python/lsst/ts/standardscripts/data/scripts/auxtel/enable_ataos_corrections.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # This file is part of ts_standardscripts
 #
 # Developed for the LSST Telescope and Site Systems.
@@ -19,25 +20,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-from .calsys_takedata import *
-from .enable_ataos_corrections import *
-from .enable_atcs import *
-from .enable_latiss import *
-from .focus_sweep_latiss import *
-from .latiss_take_sequence import *
-from .offline_atcs import *
-from .offline_latiss import *
-from .offset_ataos import *
-from .offset_atcs import *
-from .point_azel import *
-from .prepare_for.flats import *
-from .prepare_for.onsky import *
-from .shutdown import *
-from .standby_atcs import *
-from .standby_latiss import *
-from .stop import *
-from .stop_tracking import *
-from .take_image_latiss import *
-from .take_stuttered_latiss import *
-from .track_target import *
-from .track_target_and_take_image import *
+import asyncio
+
+from lsst.ts.standardscripts.auxtel import EnableATAOSCorrections
+
+asyncio.run(EnableATAOSCorrections.amain())

--- a/tests/test_auxtel_enable_ataos_corrections.py
+++ b/tests/test_auxtel_enable_ataos_corrections.py
@@ -37,15 +37,14 @@ class TestEnableATAOSCorrections(
 ):
     async def basic_make_script(self, index):
         self.script = EnableATAOSCorrections(index=index)
-        self.script.atcs.check = unittest.mock.Mock()
         self.atcs_mock = ATCSMock()
 
         return (self.script, self.atcs_mock)
 
     async def test_run(self):
         async with self.make_script():
-            await self.script.atcs.enable()
             await self.configure_script()
+            await self.script.atcs.enable()
 
             await self.run_script()
 
@@ -71,7 +70,7 @@ class TestEnableATAOSCorrections(
             components = ["not_atcs_comp", "atmcs"]
             await self.configure_script(ignore=components)
 
-            self.script.atcs.check.not_atcs_comp.assert_not_called()
+            assert hasattr(self.script.atcs, "not_atcs_comp") is False
             assert self.script.atcs.check.atmcs is False
 
 

--- a/tests/test_auxtel_enable_ataos_corrections.py
+++ b/tests/test_auxtel_enable_ataos_corrections.py
@@ -1,0 +1,79 @@
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import logging
+import random
+import unittest
+
+from lsst.ts import standardscripts
+from lsst.ts.observatory.control.mock import ATCSMock
+from lsst.ts.standardscripts.auxtel import EnableATAOSCorrections
+
+random.seed(47)  # for set_random_lsst_dds_partition_prefix
+
+logging.basicConfig()
+
+
+class TestEnableATAOSCorrections(
+    standardscripts.BaseScriptTestCase, unittest.IsolatedAsyncioTestCase
+):
+    async def basic_make_script(self, index):
+        self.script = EnableATAOSCorrections(index=index)
+        self.script.atcs.check = unittest.mock.Mock()
+        self.atcs_mock = ATCSMock()
+
+        return (self.script, self.atcs_mock)
+
+    async def test_run(self):
+        async with self.make_script():
+            await self.script.atcs.enable()
+            await self.configure_script()
+
+            await self.run_script()
+
+            # Testing only corrections enabled by atcs.enable_ataos_corrections
+            assert self.atcs_mock.ataos.evt_correctionEnabled.data.m1
+            assert self.atcs_mock.ataos.evt_correctionEnabled.data.hexapod
+            assert self.atcs_mock.ataos.evt_correctionEnabled.data.atspectrograph
+
+    async def test_executable(self):
+        scripts_dir = standardscripts.get_scripts_dir()
+        script_path = scripts_dir / "auxtel" / "enable_ataos_corrections.py"
+        await self.check_executable(script_path)
+
+    async def test_configure_ignore(self):
+        async with self.make_script():
+            components = ["atmcs"]
+            await self.configure_script(ignore=components)
+
+            assert self.script.atcs.check.atmcs is False
+
+    async def test_configure_ignore_not_atcs_component(self):
+        async with self.make_script():
+            components = ["not_atcs_comp", "atmcs"]
+            await self.configure_script(ignore=components)
+
+            self.script.atcs.check.not_atcs_comp.assert_not_called()
+            assert self.script.atcs.check.atmcs is False
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add SAL script to enable ATAOS corrections but skipping having the corrections as a configuration option.