### PR TITLE
Add DisableATAOSCorrections script for auxtel

### DIFF
--- a/doc/news/DM-44630.feature.rst
+++ b/doc/news/DM-44630.feature.rst
@@ -1,0 +1,1 @@
+Add `DisableATAOSCorrections` SAL script for `auxtel`.

--- a/python/lsst/ts/standardscripts/auxtel/disable_ataos_corrections.py
+++ b/python/lsst/ts/standardscripts/auxtel/disable_ataos_corrections.py
@@ -1,0 +1,99 @@
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__all__ = ["DisableATAOSCorrections"]
+
+import yaml
+from lsst.ts import salobj
+from lsst.ts.observatory.control.auxtel.atcs import ATCS, ATCSUsages
+
+
+class DisableATAOSCorrections(salobj.BaseScript):
+    """Disable ATAOS corrections as a stand alone operation.
+
+    Parameters
+    ----------
+    index : `int`
+        Index of Script SAL component.
+
+    """
+
+    def __init__(self, index):
+        super().__init__(index=index, descr="Disable ATAOS corrections")
+        self.atcs = None
+
+    @classmethod
+    def get_schema(cls):
+        schema_yaml = """
+            $schema: http://json-schema.org/draft-07/schema#
+            $id: https://github.com/lsst-ts/ts_standardscripts/auxtel/enable_latiss.yaml
+            title: DisableATAOSCorrections v1
+            description: Configuration for DisableATAOSCorrections
+            type: object
+            properties:
+                ignore_fail:
+                    description: Should it be ignored if the disable operation fails?
+                        If False and the attempt to disable ATAOS corrections fails, an exception is raised.
+                        If True and the attempt to disable ATAOS corrections fails, no exception is raised.
+                        If disabling ATAOS corrections is successful, the parameter has no effect.
+                    type: boolean
+                    default: true
+
+                ignore:
+                    description: >-
+                        CSCs from the group to ignore. Name must match those in
+                        self.group.components, e.g.; atmcs.
+                    type: array
+                    items:
+                        type: string
+
+            additionalProperties: false
+        """
+        return yaml.safe_load(schema_yaml)
+
+    async def configure(self, config):
+        self.config = config
+        self.ignore_fail = config.ignore_fail
+
+        if self.atcs is None:
+            self.atcs = ATCS(
+                domain=self.domain, intended_usage=ATCSUsages.All, log=self.log
+            )
+            await self.atcs.start_task
+
+        if hasattr(self.config, "ignore"):
+            for comp in self.config.ignore:
+                if comp not in self.atcs.components_attr:
+                    self.log.warning(
+                        f"Component {comp} not in CSC Group. "
+                        f"Must be one of {self.atcs.components_attr}. Ignoring."
+                    )
+                else:
+                    self.log.debug(f"Ignoring component {comp}.")
+                    setattr(self.atcs.check, comp, False)
+
+    def set_metadata(self, metadata):
+        pass
+
+    async def run(self):
+        """Run script."""
+        await self.atcs.assert_all_enabled()
+        await self.atcs.disable_ataos_corrections(ignore_fail=self.ignore_fail)

--- a/python/lsst/ts/standardscripts/data/scripts/auxtel/disable_ataos_corrections.py
+++ b/python/lsst/ts/standardscripts/data/scripts/auxtel/disable_ataos_corrections.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # This file is part of ts_standardscripts
 #
 # Developed for the LSST Telescope and Site Systems.
@@ -19,26 +20,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-from .calsys_takedata import *
-from .disable_ataos_corrections import *
-from .enable_ataos_corrections import *
-from .enable_atcs import *
-from .enable_latiss import *
-from .focus_sweep_latiss import *
-from .latiss_take_sequence import *
-from .offline_atcs import *
-from .offline_latiss import *
-from .offset_ataos import *
-from .offset_atcs import *
-from .point_azel import *
-from .prepare_for.flats import *
-from .prepare_for.onsky import *
-from .shutdown import *
-from .standby_atcs import *
-from .standby_latiss import *
-from .stop import *
-from .stop_tracking import *
-from .take_image_latiss import *
-from .take_stuttered_latiss import *
-from .track_target import *
-from .track_target_and_take_image import *
+import asyncio
+
+from lsst.ts.standardscripts.auxtel import DisableATAOSCorrections
+
+asyncio.run(DisableATAOSCorrections.amain())

--- a/tests/test_auxtel_disable_ataos_corrections.py
+++ b/tests/test_auxtel_disable_ataos_corrections.py
@@ -1,0 +1,103 @@
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import logging
+import random
+import unittest
+
+from lsst.ts import standardscripts
+from lsst.ts.observatory.control.mock import ATCSMock
+from lsst.ts.standardscripts.auxtel import DisableATAOSCorrections
+
+random.seed(47)  # for set_random_lsst_dds_partition_prefix
+
+logging.basicConfig()
+
+
+class TestDisableATAOSCorrections(
+    standardscripts.BaseScriptTestCase, unittest.IsolatedAsyncioTestCase
+):
+
+    async def basic_make_script(self, index):
+        self.script = DisableATAOSCorrections(index=index)
+        self.atcs_mock = ATCSMock()
+
+        return (self.script, self.atcs_mock)
+
+    async def test_configure_ignore(self):
+        async with self.make_script():
+            # Test ignore feature.
+            await self.configure_script(ignore=["atmcs", "atpneumatics"])
+
+            assert not self.script.atcs.check.atmcs
+            assert not self.script.atcs.check.atpneumatics
+
+    async def test_configure_ignore_not_atcs_component(self):
+        async with self.make_script():
+            # Test the ignore feature with one non-ATCS component.
+            components = ["not_atcs_comp", "atmcs"]
+            await self.configure_script(ignore=components)
+
+            assert not hasattr(self.script.atcs.check, "not_atcs_comp")
+            assert self.script.atcs.check.atmcs is False
+
+    async def test_configure_ignore_fail(self):
+        # Test the ignore_fail configuration.
+        async with self.make_script():
+            # Test default value for ignore_fail
+            await self.configure_script()
+            assert self.script.ignore_fail
+            # Test configuring ingore_fail value
+            config_values = [True, False]
+            for test_value in config_values:
+                await self.configure_script(ignore_fail=test_value)
+                assert self.script.ignore_fail == test_value
+
+    async def test_run(self):
+        async with self.make_script():
+            await self.configure_script()
+            await self.script.atcs.enable()
+
+            await self.run_script()
+            # TODO: Find a way to get the list of corrections for ATAOS to
+            #       avoid hardcoding.
+            ataos_corrections = [
+                "m1",
+                "m2",
+                "hexapod",
+                "focus",
+                "atspectrograph",
+                "moveWhileExposing",
+            ]
+            # Check that all corrections are disabled.
+            for correction in ataos_corrections:
+                assert not getattr(
+                    self.atcs_mock.ataos.evt_correctionEnabled.data, correction
+                )
+
+    async def test_executable(self):
+        scripts_dir = standardscripts.get_scripts_dir()
+        script_path = scripts_dir / "auxtel" / "disable_ataos_corrections.py"
+        await self.check_executable(script_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add SAL script to disable ATAOS corrections but skipping having the corrections as a configuration option.
