### PR TITLE
DM-45637: Implement block related functionality in the ScriptQueue and Scripts.

### DIFF
--- a/doc/news/DM-45637.feature.rst
+++ b/doc/news/DM-45637.feature.rst
@@ -1,0 +1,1 @@
+Update unit tests for BaseBlockScript to work with the latest version of salobj that adds support for block to BaseScript.

--- a/tests/test_auxtel_point_azel.py
+++ b/tests/test_auxtel_point_azel.py
@@ -98,6 +98,9 @@ class TestPointAzEl(BaseScriptTestCase, unittest.IsolatedAsyncioTestCase):
             self.script.atcs.check.no_comp.assert_not_called()
             self.script.configure_tcs.assert_awaited_once()
 
+    @unittest.mock.patch(
+        "lsst.ts.standardscripts.BaseBlockScript.obs_id", "202306060001"
+    )
     async def test_configure_with_program_reason(self):
         """Testing a valid configuration: with program and reason"""
 

--- a/tests/test_base_block_script.py
+++ b/tests/test_base_block_script.py
@@ -46,6 +46,9 @@ class TestBaseBlockScript(
             self.script.mtcs.components_attr = ["mtm1m3"]
             yield
 
+    @unittest.mock.patch(
+        "lsst.ts.standardscripts.BaseBlockScript.obs_id", "202306060001"
+    )
     async def test_config_fail_test_case_name_only(self):
         async with self.make_dry_script():
             self.script.get_obs_id = unittest.mock.AsyncMock(
@@ -70,6 +73,9 @@ class TestBaseBlockScript(
                     test_case=test_case,
                 )
 
+    @unittest.mock.patch(
+        "lsst.ts.standardscripts.BaseBlockScript.obs_id", "202306060001"
+    )
     async def test_config_fail_test_case_execution_only(self):
         async with self.make_dry_script():
             self.script.get_obs_id = unittest.mock.AsyncMock(
@@ -94,6 +100,9 @@ class TestBaseBlockScript(
                     test_case=test_case,
                 )
 
+    @unittest.mock.patch(
+        "lsst.ts.standardscripts.BaseBlockScript.obs_id", "202306060001"
+    )
     async def test_config_fail_test_case_version_only(self):
         async with self.make_dry_script():
             self.script.get_obs_id = unittest.mock.AsyncMock(
@@ -118,6 +127,9 @@ class TestBaseBlockScript(
                     test_case=test_case,
                 )
 
+    @unittest.mock.patch(
+        "lsst.ts.standardscripts.BaseBlockScript.obs_id", "202306060001"
+    )
     async def test_config_fail_test_case_name_execution_only(self):
         async with self.make_dry_script():
             self.script.get_obs_id = unittest.mock.AsyncMock(
@@ -142,6 +154,9 @@ class TestBaseBlockScript(
                     test_case=test_case,
                 )
 
+    @unittest.mock.patch(
+        "lsst.ts.standardscripts.BaseBlockScript.obs_id", "202306060001"
+    )
     async def test_config_fail_test_case_name_version_only(self):
         async with self.make_dry_script():
             self.script.get_obs_id = unittest.mock.AsyncMock(
@@ -166,6 +181,9 @@ class TestBaseBlockScript(
                     test_case=test_case,
                 )
 
+    @unittest.mock.patch(
+        "lsst.ts.standardscripts.BaseBlockScript.obs_id", "202306060001"
+    )
     async def test_config_fail_test_case_program_version_only(self):
         async with self.make_dry_script():
             self.script.get_obs_id = unittest.mock.AsyncMock(
@@ -190,6 +208,9 @@ class TestBaseBlockScript(
                     test_case=test_case,
                 )
 
+    @unittest.mock.patch(
+        "lsst.ts.standardscripts.BaseBlockScript.obs_id", "202306060001"
+    )
     async def test_config_reason_program(self) -> None:
         async with self.make_dry_script():
             self.script.get_obs_id = unittest.mock.AsyncMock(
@@ -217,6 +238,9 @@ class TestBaseBlockScript(
                 == "MoveP2P BLOCK-123 202306060001 SITCOM-321"
             )
 
+    @unittest.mock.patch(
+        "lsst.ts.standardscripts.BaseBlockScript.obs_id", "202306060001"
+    )
     async def test_config_reason_program_test_case(self) -> None:
         async with self.make_dry_script():
             self.script.get_obs_id = unittest.mock.AsyncMock(
@@ -251,6 +275,9 @@ class TestBaseBlockScript(
                 == "MoveP2P BLOCK-123 202306060001 SITCOM-321"
             )
 
+    @unittest.mock.patch(
+        "lsst.ts.standardscripts.BaseBlockScript.obs_id", "202306060001"
+    )
     async def test_config_reason_program_test_case_initial_step(self) -> None:
         async with self.make_dry_script():
             self.script.get_obs_id = unittest.mock.AsyncMock(
@@ -287,6 +314,9 @@ class TestBaseBlockScript(
                 == "MoveP2P BLOCK-123 202306060001 SITCOM-321"
             )
 
+    @unittest.mock.patch(
+        "lsst.ts.standardscripts.BaseBlockScript.obs_id", "202306060001"
+    )
     async def test_config_reason_program_test_case_project(self) -> None:
         async with self.make_dry_script():
             self.script.get_obs_id = unittest.mock.AsyncMock(
@@ -354,6 +384,9 @@ class TestBaseBlockScript(
             assert obs_id is not None
             assert obs_id.startswith("BT123")
 
+    @unittest.mock.patch(
+        "lsst.ts.standardscripts.BaseBlockScript.obs_id", "202306060001"
+    )
     async def test_config_reason_program_block_test_case(self) -> None:
         async with self.make_dry_script():
             self.script.get_obs_id = unittest.mock.AsyncMock(
@@ -423,6 +456,9 @@ class TestBaseBlockScript(
 
             assert not self.script.evt_largeFileObjectAvailable.has_data
 
+    @unittest.mock.patch(
+        "lsst.ts.standardscripts.BaseBlockScript.obs_id", "202306060001"
+    )
     async def test_run_with_test_case(self):
         async with self.make_dry_script():
             self.script.get_obs_id = unittest.mock.AsyncMock(
@@ -474,6 +510,9 @@ class TestBaseBlockScript(
             for test_step in self.script.step_results:
                 assert test_step["status"] == "PASSED"
 
+    @unittest.mock.patch(
+        "lsst.ts.standardscripts.BaseBlockScript.obs_id", "202306060001"
+    )
     async def test_run_fail_with_test_case(self):
         async with self.make_dry_script():
             self.script.get_obs_id = unittest.mock.AsyncMock(

--- a/tests/test_maintel_disable_hexapod_compensation_mode.py
+++ b/tests/test_maintel_disable_hexapod_compensation_mode.py
@@ -60,6 +60,9 @@ class TestDisableHexapodCompensationMode(
             with pytest.raises(salobj.ExpectedError):
                 await self.configure_script(components=components)
 
+    @unittest.mock.patch(
+        "lsst.ts.standardscripts.BaseBlockScript.obs_id", "202306060001"
+    )
     async def test_configure_with_program_reason(self):
         async with self.make_dry_script():
             self.script.get_obs_id = unittest.mock.AsyncMock(

--- a/tests/test_maintel_disable_m1m3_balance_system.py
+++ b/tests/test_maintel_disable_m1m3_balance_system.py
@@ -50,6 +50,9 @@ class TestDisableM1M3BalanceSystem(
             assert self.script.reason is None
             assert self.script.checkpoint_message is None
 
+    @unittest.mock.patch(
+        "lsst.ts.standardscripts.BaseBlockScript.obs_id", "202306060001"
+    )
     async def test_configure_with_program_reason(self):
         """Testing a valid configuration: with program and reason"""
 

--- a/tests/test_maintel_enable_hexapod_compensation_mode.py
+++ b/tests/test_maintel_enable_hexapod_compensation_mode.py
@@ -58,6 +58,9 @@ class TestEnableHexapodCompensationMode(
             with pytest.raises(salobj.ExpectedError):
                 await self.configure_script(components=components)
 
+    @unittest.mock.patch(
+        "lsst.ts.standardscripts.BaseBlockScript.obs_id", "202306060001"
+    )
     async def test_configure_with_program_reason(self):
         async with self.make_dry_script():
             self.script.get_obs_id = unittest.mock.AsyncMock(

--- a/tests/test_maintel_enable_m1m3_balance_system.py
+++ b/tests/test_maintel_enable_m1m3_balance_system.py
@@ -48,6 +48,9 @@ class TestEnableM1M3BalanceSystem(
             assert self.script.reason is None
             assert self.script.checkpoint_message is None
 
+    @unittest.mock.patch(
+        "lsst.ts.standardscripts.BaseBlockScript.obs_id", "202306060001"
+    )
     async def test_configure_with_program_reason(self):
         """Testing a valid configuration: with program and reason"""
 

--- a/tests/test_maintel_lower_m1m3.py
+++ b/tests/test_maintel_lower_m1m3.py
@@ -48,6 +48,9 @@ class TestLowerM1M3(
             assert self.script.reason is None
             assert self.script.checkpoint_message is None
 
+    @unittest.mock.patch(
+        "lsst.ts.standardscripts.BaseBlockScript.obs_id", "202306060001"
+    )
     async def test_configure_with_program_reason(self):
         """Testing a valid configuration: with program and reason"""
 

--- a/tests/test_maintel_m1m3_check_actuators.py
+++ b/tests/test_maintel_m1m3_check_actuators.py
@@ -140,6 +140,9 @@ class TestCheckActuators(BaseScriptTestCase, unittest.IsolatedAsyncioTestCase):
                         actuators=actuators_bad_ids,
                     )
 
+    @unittest.mock.patch(
+        "lsst.ts.standardscripts.BaseBlockScript.obs_id", "202306060001"
+    )
     async def test_configure_with_program_reason(self):
         """Testing a valid configuration: with program and reason"""
 

--- a/tests/test_maintel_m1m3_check_hardpoint.py
+++ b/tests/test_maintel_m1m3_check_hardpoint.py
@@ -89,6 +89,9 @@ class TestCheckHardpoint(
             assert self.script.reason is None
             assert self.script.checkpoint_message is None
 
+    @unittest.mock.patch(
+        "lsst.ts.standardscripts.BaseBlockScript.obs_id", "202306060001"
+    )
     async def test_configure_with_program_reason(self):
         """Testing a valid configuration: with program and reason"""
 

--- a/tests/test_maintel_m1m3_enable_m1m3_controller_flags.py
+++ b/tests/test_maintel_m1m3_enable_m1m3_controller_flags.py
@@ -80,6 +80,9 @@ class TestEnableM1M3SlewControllerFlags(
                     slew_flags=["ACCELERATIONFORCES"], enable=[True, False]
                 )
 
+    @unittest.mock.patch(
+        "lsst.ts.standardscripts.BaseBlockScript.obs_id", "202306060001"
+    )
     async def test_configure_with_program_reason(self):
         async with self.make_dry_script():
             self.script.get_obs_id = unittest.mock.AsyncMock(

--- a/tests/test_maintel_m2_check_actuators.py
+++ b/tests/test_maintel_m2_check_actuators.py
@@ -130,6 +130,9 @@ class TestCheckActuators(BaseScriptTestCase, unittest.IsolatedAsyncioTestCase):
                     actuators=actuators,
                 )
 
+    @unittest.mock.patch(
+        "lsst.ts.standardscripts.BaseBlockScript.obs_id", "202306060001"
+    )
     async def test_configure_with_program_reason(self):
         """Testing a valid configuration: with program and reason"""
 

--- a/tests/test_maintel_m2_disable_closed_loop.py
+++ b/tests/test_maintel_m2_disable_closed_loop.py
@@ -44,6 +44,9 @@ class TestDisableM2ClosedLoop(
             self.script.mtcs.disable_m2_balance_system = unittest.mock.AsyncMock()
             yield
 
+    @unittest.mock.patch(
+        "lsst.ts.standardscripts.BaseBlockScript.obs_id", "202306060001"
+    )
     async def test_configure_with_program_reason(self):
         async with self.make_dry_script():
             self.script.get_obs_id = unittest.mock.AsyncMock(

--- a/tests/test_maintel_m2_enable_closed_loop.py
+++ b/tests/test_maintel_m2_enable_closed_loop.py
@@ -44,6 +44,9 @@ class TestEnableM2ClosedLoop(
             self.script.mtcs.enable_m2_balance_system = unittest.mock.AsyncMock()
             yield
 
+    @unittest.mock.patch(
+        "lsst.ts.standardscripts.BaseBlockScript.obs_id", "202306060001"
+    )
     async def test_configure_with_program_reason(self):
         async with self.make_dry_script():
             self.script.get_obs_id = unittest.mock.AsyncMock(

--- a/tests/test_maintel_move_p2p.py
+++ b/tests/test_maintel_move_p2p.py
@@ -265,6 +265,9 @@ class TestMoveP2P(standardscripts.BaseScriptTestCase, unittest.IsolatedAsyncioTe
             assert self.script.reason is None
             assert self.script.checkpoint_message is None
 
+    @unittest.mock.patch(
+        "lsst.ts.standardscripts.BaseBlockScript.obs_id", "202306060001"
+    )
     async def test_config_pause_for_reason_program(self) -> None:
         async with self.make_dry_script():
             self.script.get_obs_id = unittest.mock.AsyncMock(

--- a/tests/test_maintel_mtrotator_move_rotator.py
+++ b/tests/test_maintel_mtrotator_move_rotator.py
@@ -73,6 +73,9 @@ class TestMoveRotator(
             assert self.script.reason is None
             assert self.script.checkpoint_message is None
 
+    @unittest.mock.patch(
+        "lsst.ts.standardscripts.BaseBlockScript.obs_id", "202306060001"
+    )
     async def test_configure_with_program_reason(self):
         """Testing a valid configuration: with program and reason"""
 

--- a/tests/test_maintel_point_azel.py
+++ b/tests/test_maintel_point_azel.py
@@ -89,6 +89,9 @@ class TestPointAzEl(BaseScriptTestCase, unittest.IsolatedAsyncioTestCase):
             assert self.script.mtcs.check.mtdometrajectory is False
             self.script.mtcs.check.no_comp.assert_not_called()
 
+    @unittest.mock.patch(
+        "lsst.ts.standardscripts.BaseBlockScript.obs_id", "202306060001"
+    )
     async def test_configure_with_program_reason(self):
         """Testing a valid configuration: with program and reason"""
 

--- a/tests/test_maintel_raise_m1m3.py
+++ b/tests/test_maintel_raise_m1m3.py
@@ -48,6 +48,9 @@ class TestRaiseM1M3(
             assert self.script.reason is None
             assert self.script.checkpoint_message is None
 
+    @unittest.mock.patch(
+        "lsst.ts.standardscripts.BaseBlockScript.obs_id", "202306060001"
+    )
     async def test_configure_with_program_reason(self):
         """Testing a valid configuration: with program and reason"""
 

--- a/tests/test_maintel_track_target.py
+++ b/tests/test_maintel_track_target.py
@@ -122,6 +122,9 @@ class TestMTSlew(standardscripts.BaseScriptTestCase, unittest.IsolatedAsyncioTes
             assert self.script.reason is None
             assert self.script.checkpoint_message is None
 
+    @unittest.mock.patch(
+        "lsst.ts.standardscripts.BaseBlockScript.obs_id", "202306060001"
+    )
     async def test_configure_with_target_name_program_reason(self):
         """Testing a valid configuration: with program and reason"""
 


### PR DESCRIPTION
This PR is mainly to add backward compatibility for the unit tests. 

Once we roll this feature to the summit we can start removing the BaseBlockScript functionality.