### PR TITLE
tickets/DM-45216

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,6 @@
 DevelopPipeline(
     name: "ts_standardscripts",
     module_name: "lsst.ts.standardscripts",
-    extra_packages: ["lsst-ts/ts_cRIOpy", "lsst-ts/ts_observatory_control",
-                     "lsst-ts/ts_salobj@tickets/DM-45216"],
+    extra_packages: ["lsst-ts/ts_cRIOpy", "lsst-ts/ts_observatory_control"],
     build_all_idl: true
 )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,7 @@
 DevelopPipeline(
     name: "ts_standardscripts",
     module_name: "lsst.ts.standardscripts",
-    extra_packages: ["lsst-ts/ts_cRIOpy", "lsst-ts/ts_observatory_control"],
+    extra_packages: ["lsst-ts/ts_cRIOpy", "lsst-ts/ts_observatory_control",
+                     "lsst-ts/ts_salobj@tickets/DM-45216"],
     build_all_idl: true
 )

--- a/doc/news/DM-45216.feature.rst
+++ b/doc/news/DM-45216.feature.rst
@@ -1,0 +1,1 @@
+- Modified `SetSummaryState` to send all instances of a CSC to a desired state.

--- a/python/lsst/ts/standardscripts/set_summary_state.py
+++ b/python/lsst/ts/standardscripts/set_summary_state.py
@@ -25,7 +25,13 @@ import asyncio
 
 import yaml
 from lsst.ts import salobj
-from lsst.ts.salobj.base import WildcardIndexError
+
+try:
+    from lsst.ts.salobj import WildcardIndexError, name_to_name_index
+except ImportError:
+    # If not available in ts_salobj, use the local fallback from utils
+    from lsst.ts.standardscripts.utils import name_to_name_index, WildcardIndexError
+
 from lsst.ts.standardscripts.utils import find_running_instances
 
 
@@ -136,7 +142,7 @@ class SetSummaryState(salobj.BaseScript):
 
             try:
                 # Try to parse the name and index
-                name, index = salobj.name_to_name_index(elt[0])
+                name, index = name_to_name_index(elt[0])
             except WildcardIndexError as e:
                 name = e.name
                 index = "*"  # Mark as wildcard

--- a/tests/test_system_wide_shutdown.py
+++ b/tests/test_system_wide_shutdown.py
@@ -25,6 +25,7 @@ import unittest
 import pytest
 from lsst.ts import salobj, standardscripts
 from lsst.ts.standardscripts import SystemWideShutdown
+from lsst.ts.standardscripts.utils import find_running_instances
 
 
 class TestSystemWideShutdown(
@@ -81,8 +82,8 @@ class TestSystemWideShutdown(
         self.make_test_cscs = True
 
         async with self.make_script():
-            component, component_indices = await self.script.find_running_instances(
-                "Test"
+            component, component_indices = await find_running_instances(
+                self.script.domain, "Test"
             )
 
             assert component == "Test"
@@ -90,8 +91,8 @@ class TestSystemWideShutdown(
 
     async def test_find_running_instances_not_running(self):
         async with self.make_script():
-            component, component_indices = await self.script.find_running_instances(
-                "Test"
+            component, component_indices = await find_running_instances(
+                self.script.domain, "Test"
             )
 
             assert component == "Test"


### PR DESCRIPTION
Changes to the `SetSummaryState` script by adding support for handling wildcard indices (`*`) in CSC name indices, allowing for the discovery and configuration of multiple CSC instances. It also includes a series of refactorings and unittests.

Key changes:
- **Wildcard Index Handling in SetSummaryState**: 
  - The `SetSummaryState` script can now handle wildcard indices (`*`) by discovering all running instances of a CSC when the index is set to `*`.
  - Added error handling using the new `WildcardIndexError` from `salobj.base` to support special cases for wildcard indices.

- **Refactoring**:
  - Refactored the `find_running_instances` method from `SystemWideShutdown` into `utils.py` to enable its reuse across multiple scripts, such as `SetSummaryState`.
  
- **Unit Tests**:
  - Added tests to ensure correct handling of wildcard indices in `SetSummaryState`, verifying that CSCs in various states are discovered and that only active CSCs are transitioned to the `ENABLED` state.
  - New tests for the `find_running_instances` function from `utils.py` to validate the discovery of running CSCs based on their heartbeats.