### PR TITLE
DM-45975: Fixed typo for monochromator gratings

### DIFF
--- a/doc/news/DM-45975.doc.rst
+++ b/doc/news/DM-45975.doc.rst
@@ -1,0 +1,1 @@
+Updated config schema enumeration of monochromator gratings

--- a/python/lsst/ts/standardscripts/auxtel/calibrations/power_on_atcalsys.py
+++ b/python/lsst/ts/standardscripts/auxtel/calibrations/power_on_atcalsys.py
@@ -93,7 +93,7 @@ class PowerOnATCalSys(salobj.BaseScript):
                 minimum: 0
 
               grating_type:
-                description: Grating type for each image. The choices are 0=mirror, 1=blue, 2=red.
+                description: Grating type for each image. The choices are 0=mirror, 1=red, 2=blue.
                 type: integer
                 enum: [0, 1, 2]
                 default: 0


### PR DESCRIPTION
In the config schema, the enumeration for the gratings was updated to align with the hardware and updates made to the ATmonochromator XML (DM-45474).