### PR TITLE
Tickets/dm 46179 Extend TCS readiness check to other image types beyond OBJECT

### DIFF
--- a/doc/news/DM-46179.feature.1.rst
+++ b/doc/news/DM-46179.feature.1.rst
@@ -1,0 +1,5 @@
+Added expected_final_state argument to run_script method in BaseScriptTestCase
+
+We use this argument to test the overall state of the script execution.
+expected_final_state defaults to ScriptState.DONE if not passed.
+

--- a/doc/news/DM-46179.feature.rst
+++ b/doc/news/DM-46179.feature.rst
@@ -1,0 +1,9 @@
+Extend TCS readiness check to other image types beyond OBJECT, such as:
+ENGTEST, CWFS and ACQ.
+
+Configure TCS synchronization to the following script:
+- auxtel/daytime_checkout/slew_and_take_image_checkout.py
+- auxtel/take_image_latiss.py
+- maintel/take_image_comcam.py
+- maintel/take_image_lsstcam.py
+- maintel/take_triplet_comcam.py

--- a/python/lsst/ts/standardscripts/auxtel/daytime_checkout/slew_and_take_image_checkout.py
+++ b/python/lsst/ts/standardscripts/auxtel/daytime_checkout/slew_and_take_image_checkout.py
@@ -82,10 +82,15 @@ class SlewAndTakeImageCheckout(salobj.BaseScript):
         # super().__init__() above. We can also pass in the script domain and
         # logger to both classes so log messages generated internally are
         # published to the efd.
-        self.latiss = LATISS(
-            domain=self.domain, intended_usage=latiss_usage, log=self.log
-        )
         self.atcs = ATCS(domain=self.domain, intended_usage=atcs_usage, log=self.log)
+
+        tcs_ready_to_take_data = self.atcs if add_remotes else None
+        self.latiss = LATISS(
+            domain=self.domain,
+            intended_usage=latiss_usage,
+            log=self.log,
+            tcs_ready_to_take_data=tcs_ready_to_take_data,
+        )
 
     @classmethod
     def get_schema(cls):

--- a/python/lsst/ts/standardscripts/auxtel/take_image_latiss.py
+++ b/python/lsst/ts/standardscripts/auxtel/take_image_latiss.py
@@ -22,7 +22,7 @@
 __all__ = ["TakeImageLatiss"]
 
 import yaml
-from lsst.ts.observatory.control.auxtel import LATISS, LATISSUsages
+from lsst.ts.observatory.control.auxtel import ATCS, LATISS, ATCSUsages, LATISSUsages
 
 from ..base_take_image import BaseTakeImage
 
@@ -46,8 +46,13 @@ class TakeImageLatiss(BaseTakeImage):
     def __init__(self, index):
         super().__init__(index=index, descr="Take images with AT Camera")
 
+        self.atcs = ATCS(self.domain, log=self.log, intended_usage=ATCSUsages.Slew)
+
         self._latiss = LATISS(
-            self.domain, intended_usage=LATISSUsages.TakeImageFull, log=self.log
+            self.domain,
+            intended_usage=LATISSUsages.TakeImageFull,
+            log=self.log,
+            tcs_ready_to_take_data=self.atcs.ready_to_take_data,
         )
 
         self.instrument_name = "LATISS"

--- a/python/lsst/ts/standardscripts/base_script_test_case.py
+++ b/python/lsst/ts/standardscripts/base_script_test_case.py
@@ -232,7 +232,7 @@ class BaseScriptTestCase(metaclass=abc.ABCMeta):
     def next_index(self):
         return next(self._index_iter)
 
-    async def run_script(self):
+    async def run_script(self, expected_final_state=Script.ScriptState.DONE):
         """Run the script.
 
         Requires that the script be configured and the group ID set
@@ -241,7 +241,7 @@ class BaseScriptTestCase(metaclass=abc.ABCMeta):
         run_data = self.script.cmd_run.DataType()
         await self.script.do_run(run_data)
         await self.script.done_task
-        assert self.script.state.state == Script.ScriptState.DONE
+        assert self.script.state.state == expected_final_state
 
     async def wait_for(self, coro, timeout, description, verbose):
         """A wrapper around asyncio.wait_for that prints timing information.

--- a/python/lsst/ts/standardscripts/maintel/take_aos_sequence_comcam.py
+++ b/python/lsst/ts/standardscripts/maintel/take_aos_sequence_comcam.py
@@ -218,6 +218,7 @@ class TakeAOSSequenceComCam(BaseBlockScript):
                 self.domain,
                 log=self.log,
                 intended_usage=ComCamUsages.TakeImage + ComCamUsages.StateTransition,
+                tcs_ready_to_take_data=self.mtcs.tcs_ready_to_take_data,
             )
             await self.camera.start_task
         else:

--- a/python/lsst/ts/standardscripts/maintel/take_image_comcam.py
+++ b/python/lsst/ts/standardscripts/maintel/take_image_comcam.py
@@ -22,7 +22,9 @@
 __all__ = ["TakeImageComCam"]
 
 import yaml
+from lsst.ts.observatory.control.maintel import MTCS
 from lsst.ts.observatory.control.maintel.comcam import ComCam, ComCamUsages
+from lsst.ts.observatory.control.maintel.mtcs import MTCSUsages
 
 from ..base_take_image import BaseTakeImage
 
@@ -48,8 +50,13 @@ class TakeImageComCam(BaseTakeImage):
 
         self.config = None
 
+        self.mtcs = MTCS(self.domain, log=self.log, intended_usage=MTCSUsages.Slew)
+
         self._comcam = ComCam(
-            self.domain, intended_usage=ComCamUsages.TakeImage, log=self.log
+            self.domain,
+            intended_usage=ComCamUsages.TakeImage,
+            log=self.log,
+            tcs_ready_to_take_data=self.mtcs.ready_to_take_data,
         )
 
         self.instrument_name = "LSSTComCam"

--- a/python/lsst/ts/standardscripts/maintel/take_image_comcam.py
+++ b/python/lsst/ts/standardscripts/maintel/take_image_comcam.py
@@ -22,9 +22,8 @@
 __all__ = ["TakeImageComCam"]
 
 import yaml
-from lsst.ts.observatory.control.maintel import MTCS
 from lsst.ts.observatory.control.maintel.comcam import ComCam, ComCamUsages
-from lsst.ts.observatory.control.maintel.mtcs import MTCSUsages
+from lsst.ts.observatory.control.maintel.mtcs import MTCS, MTCSUsages
 
 from ..base_take_image import BaseTakeImage
 

--- a/python/lsst/ts/standardscripts/maintel/take_image_lsstcam.py
+++ b/python/lsst/ts/standardscripts/maintel/take_image_lsstcam.py
@@ -22,8 +22,8 @@
 __all__ = ["TakeImageLSSTCam"]
 
 import yaml
-from lsst.ts.observatory.control.maintel import MTCS
 from lsst.ts.observatory.control.maintel.lsstcam import LSSTCam, LSSTCamUsages
+from lsst.ts.observatory.control.maintel.mtcs import MTCS, MTCSUsages
 
 from ..base_take_image import BaseTakeImage
 
@@ -49,7 +49,7 @@ class TakeImageLSSTCam(BaseTakeImage):
 
         self.config = None
 
-        self.mtcs = MTCS(self.domain, log=self.log)
+        self.mtcs = MTCS(self.domain, log=self.log, intended_usage=MTCSUsages.Slew)
 
         self._lsstcam = LSSTCam(
             self.domain,

--- a/python/lsst/ts/standardscripts/maintel/take_image_lsstcam.py
+++ b/python/lsst/ts/standardscripts/maintel/take_image_lsstcam.py
@@ -22,6 +22,7 @@
 __all__ = ["TakeImageLSSTCam"]
 
 import yaml
+from lsst.ts.observatory.control.maintel import MTCS
 from lsst.ts.observatory.control.maintel.lsstcam import LSSTCam, LSSTCamUsages
 
 from ..base_take_image import BaseTakeImage
@@ -48,8 +49,13 @@ class TakeImageLSSTCam(BaseTakeImage):
 
         self.config = None
 
+        self.mtcs = MTCS(self.domain, log=self.log)
+
         self._lsstcam = LSSTCam(
-            self.domain, intended_usage=LSSTCamUsages.TakeImage, log=self.log
+            self.domain,
+            intended_usage=LSSTCamUsages.TakeImage,
+            log=self.log,
+            tcs_ready_to_take_data=self.mtcs.ready_to_take_data,
         )
 
         self.instrument_setup_time = self._lsstcam.filter_change_timeout


### PR DESCRIPTION
https://rubinobs.atlassian.net/browse/DM-46179

Before I keep going I want to make sure I'm not deviating from the intended development objectives. Specially for the unit tests. Thanks!