### PR TITLE
Tickets/DM-47618: Add mechanism to run the m1m3 bump test on the last failed actuators

### DIFF
--- a/doc/news/DM-47618.feature.rst
+++ b/doc/news/DM-47618.feature.rst
@@ -1,0 +1,1 @@
+Add ``last_failed`` option to the ``CheckActuators`` script to run bump tests on actuators that failed their last test.


### PR DESCRIPTION
Add `last_failed` option to the `CheckActuators` script to run bump tests on actuators that failed their last test.