### PR TITLE
Tickets/dm 48022

### DIFF
--- a/doc/news/DM-48022.feature.rst
+++ b/doc/news/DM-48022.feature.rst
@@ -1,0 +1,5 @@
+Added new property `disable_m1m3_force_balance` with default `false`.
+Maintains the ability to disable the M1M3 balance system, in case
+the coupling effect between the elevation axis and m1m3
+support system, repeats again, driving the system to a huge
+oscillation

--- a/doc/news/DM-48022.removal.rst
+++ b/doc/news/DM-48022.removal.rst
@@ -1,0 +1,1 @@
+Deprecate `ignore_m1m3` property.


### PR DESCRIPTION
https://rubinobs.atlassian.net/browse/DM-48022 

Deprecate ignore_m1m3 added disable_m1m3_force_balance property
    
    - Deprecate `ignore_m1m3` property.
    - Added new property `disable_m1m3_force_balance` with default `false`.
        Maintains the ability to disable the M1M3 balance system, in case
        the coupling effect between the elevation axis and m1m3
        support system, repeats again, driving the system to a huge
        oscillation
    - Added unit tests for the property deprecation and the new one
