### PR TITLE
DM-46005 Add AT venting start script.

### DIFF
--- a/doc/news/DM-46005.feature.rst
+++ b/doc/news/DM-46005.feature.rst
@@ -1,0 +1,1 @@
+Added new script ``atvent_start.py``.

--- a/python/lsst/ts/standardscripts/data/scripts/auxtel/atvent_start.py
+++ b/python/lsst/ts/standardscripts/data/scripts/auxtel/atvent_start.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# This file is part of ts_standardscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import asyncio
+
+from lsst.ts.auxtel.standardscripts import ATVentStart
+
+if __name__ == "__main__":
+    asyncio.run(ATVentStart.amain())

--- a/tests/test_auxtel_executables.py
+++ b/tests/test_auxtel_executables.py
@@ -39,6 +39,10 @@ class TestExecutables(
         script_path = self.scripts_dir / "daytime_checkout" / "atpneumatics_checkout.py"
         await self.check_executable(script_path)
 
+    async def test_atvent_start(self):
+        script_path = self.scripts_dir / "atvent_start.py"
+        await self.check_executable(script_path)
+
     async def test_calsys_takedata(self):
         script_path = self.scripts_dir / "calsys_takedata.py"
         await self.check_executable(script_path)


### PR DESCRIPTION
This adds a SAL script to start the AT dome venting system. The script works as follows:

1. The script is specifically for the start of venting. It could also be used to stop venting, but I intend to have a second script for that purpose.
2. The script takes two arguments: fan_frequency and gates_to_open.
3. The fan_frequency is the desired fan frequency in Hz. If omitted, no commands are sent to the fan. If zero, the fan is stopped.
4. gates_to_open is a list of the gates that should be opened. Any gates not in this list are commanded to close. If the list is omitted, no commands are sent to the gates.
5. The script should be called when the CSC is ENABLED.
6. The telemetry/events are checked to verify that the commands worked as expected.