### PR TITLE
Tickets/osw 897 Ensure calibration scripts are enforcing required MTCS state

### DIFF
--- a/doc/news/OSW-897.feature.rst
+++ b/doc/news/OSW-897.feature.rst
@@ -1,0 +1,1 @@
+Ensure scripts used to take calibrations for SimonyiTel are enforcing the required MTCS state.

--- a/python/lsst/ts/standardscripts/base_take_image.py
+++ b/python/lsst/ts/standardscripts/base_take_image.py
@@ -245,7 +245,17 @@ class BaseTakeImage(salobj.BaseScript, metaclass=abc.ABCMeta):
         if self.get_instrument_filter() is not None:
             metadata.filters = str(self.get_instrument_filter())
 
+    async def assert_feasibility(self):
+        """Hook to assert preconditions before running.
+
+        By default this does nothing. Subclasses may override to enforce
+        instrument- or environment-specific feasibility checks (e.g., CSC
+        states) prior to taking data.
+        """
+        return None
+
     async def run(self):
+        await self.assert_feasibility()
         nimages = len(self.config.exp_times)
         note = getattr(self.config, "note", None)
         reason = getattr(self.config, "reason", None)


### PR DESCRIPTION
Add assert_feasibility hooks to ensure MTDomeTrajectory is ENABLED and MTDome is at least DISABLED before taking flat-field calibrations. This prevents vignetting state from being UNKNOWN and data landing on embargoed rack.

- Add assert_feasibility() to BaseTakeImage and BaseMakeCalibrations
- Implement dome state checks in TakeImageLSSTCam, MakeLSSTCamCalibrations, and TakeWhiteLightFlatsLSSTCam
- Unit tests